### PR TITLE
README: discoverability + clarity revamp, plus LICENSE and SECURITY.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@ wheels/
 
 fzxu_git.sh
 *.json
+
+# Personal process artifacts (design specs + implementation plans)
+# These are working notes for the maintainer, not public docs.
+docs/superpowers/
+
+# Local worktrees
+.worktrees/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 anon-proxy contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,40 @@
 
 # anon-proxy
 
-An LLM API proxy that masks PII before requests leave your device and unmasks it in responses. The [openai/privacy-filter](https://huggingface.co/openai/privacy-filter) model runs **locally** — raw PII never reaches the upstream API.
+**Use Claude Code, ChatGPT, and other LLM APIs on sensitive data without sending raw PII to the cloud.** A local privacy proxy that masks personal information *before* requests leave your device and unmasks it in responses. The [openai/privacy-filter](https://huggingface.co/openai/privacy-filter) model runs entirely on your machine — names, emails, phone numbers, and addresses never reach Anthropic, OpenAI, or any other upstream API.
+
+![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)
+![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)
+![Works with Claude Code](https://img.shields.io/badge/works%20with-Claude%20Code-orange)
 
 ```
 your client  →  anon-proxy (mask/unmask)  →  api.anthropic.com | api.openai.com | ...
 ```
+
+---
+
+## Who is this for?
+
+- **Engineers in regulated industries** (healthcare, legal, finance) whose employer policy or compliance regime (HIPAA, GDPR, SOC 2) blocks raw customer data from being sent to third-party LLM APIs.
+- **Developers using Claude Code or OpenAI SDKs on production data** — debugging customer support tickets, summarizing user emails, analyzing logs that contain real names and identifiers.
+- **Privacy-conscious users** who want LLM productivity without the data exhaust of pasting personal information into a cloud model.
+- **Self-hosters** building on top of LLM APIs who need a redaction layer between their app and the provider.
+
+If you've ever caught yourself manually find-and-replacing real names in a prompt, this is for you.
+
+---
+
+## Why not just use X?
+
+| Tool | What it does | Why it's not the same |
+|---|---|---|
+| **Microsoft Presidio** | Regex + spaCy NER for PII detection | Library, not a proxy. You still have to wire it into every LLM call yourself. No stable token mapping across turns. |
+| **AWS Comprehend / GCP DLP** | Cloud-based PII detection APIs | Sends your data to *another* cloud provider. Defeats the purpose if your goal is "nothing leaves the box." |
+| **LiteLLM proxy** | Multi-provider LLM routing | Doesn't redact. Solves a different problem (routing/cost) entirely. |
+| **Prompting "please don't log my data"** | 🙏 | Not a security model. |
+| **anon-proxy** | Local ML detector + transparent proxy with stable per-session placeholders | Drop-in `ANTHROPIC_BASE_URL` / `OPENAI_BASE_URL` swap. No code changes in the client. PII gets the same placeholder every turn so the model stays coherent. |
+
+---
 
 ## Multi-provider support
 
@@ -169,7 +198,7 @@ With `--debug`, each request prints a compact diff to stderr:
 
 **What gets protected:** every user and assistant message turn — text content, tool call inputs (`tool_use.input`), and tool results (`tool_result.content`). File contents, shell output, names, emails, paths containing PII are all masked before leaving your machine.
 
-**What is NOT masked:** the system prompt (tool schemas and static instructions), tool definitions, and extended-thinking blocks (signatures would break).
+**What is NOT masked:** the system prompt (tool schemas and static instructions), tool definitions, and extended-thinking blocks (signatures would break). See [`SECURITY.md`](SECURITY.md) for the full threat model and known limitations.
 
 **How it works:** PII spans get stable placeholder tokens (`<PERSON_1>`, `<EMAIL_1>`, `<ADDRESS_1>`, …) stored in a per-session dictionary. The same value always maps to the same token across turns so the model stays coherent. Responses are unmasked before reaching your client.
 
@@ -186,6 +215,46 @@ Copy from the `.example` files to get started.
 
 ---
 
+## FAQ
+
+### How is this different from Microsoft Presidio?
+
+Presidio is a Python library for PII detection — you call it from your code. anon-proxy is a transparent network proxy: you point your existing LLM client at it via `ANTHROPIC_BASE_URL` or `OPENAI_BASE_URL` and it intercepts every request. It also maintains a stable token↔value mapping across turns, so the model sees the same `<PERSON_1>` on turn 5 that it saw on turn 1 (Presidio doesn't do this — that's an application-layer concern it leaves to you).
+
+### Does this work with Claude Code?
+
+Yes. That's the primary supported client. Set `ANTHROPIC_BASE_URL=http://127.0.0.1:8080/anthropic` and run `claude` normally. See [Using with Claude Code](#using-with-claude-code).
+
+### Does this work with OpenAI / ChatGPT SDK clients?
+
+Yes — point your OpenAI client at `http://127.0.0.1:8080/openai`. See [Using with OpenAI SDK](#using-with-openai-sdk).
+
+### Will the LLM still understand my prompt after PII is replaced with placeholders?
+
+Generally yes. Modern LLMs treat `<PERSON_1>` and `<EMAIL_1>` as opaque variable names and reason about relationships between them. The stable mapping (same person → same token across turns) is what makes multi-turn conversations work — without it, "tell <PERSON_1> about the meeting" on turn 2 would refer to a different person than turn 1's `<PERSON_1>`.
+
+### Does masking break tool calls?
+
+Tool inputs and tool results are masked/unmasked just like message text, so most tools work unchanged. Caveat: if a tool's behavior depends on the literal value of a PII string (e.g. a database lookup that takes an email), you'll want to register that field in `--patterns` carefully — or skip masking for that tool. Extended-thinking blocks are passed through unmasked because their cryptographic signatures would break.
+
+### What PII does it detect?
+
+Out of the box: persons, emails, phone numbers, addresses, organizations, dates of birth, government IDs, and other categories from the openai/privacy-filter model. Add your own (SSN formats, internal employee IDs, project codenames) via `--patterns`.
+
+### What's the performance overhead?
+
+We don't have published benchmark numbers yet — latency measurement is on the roadmap.
+
+### Is the threat model documented?
+
+Yes — see [`SECURITY.md`](SECURITY.md). It covers what's in scope (request bodies leaving your machine through the supported adapters), what's out of scope (a malicious local user, side channels, the system prompt itself), and known false-negative modes.
+
+### How do I report a vulnerability?
+
+See [`SECURITY.md`](SECURITY.md). For a privacy tool, *quietly* is usually better than a public issue — please email the maintainer first.
+
+---
+
 ## Next steps / roadmap
 
 - **Quality assurance** : Enhance PII detection quality tracking and add comprehensive unit/integration tests with benchmarking.
@@ -193,3 +262,11 @@ Copy from the `.example` files to get started.
 - **Persistence** : Optionally persist PII mappings to disk so placeholder consistency survives server restarts.
 - **Usability** : Now supporting Anthropic and OpenAI APIs, but need more compatibility testing and expand to other potential providers.
 - **Dev infrastructure** : Set up CI, contribution guidelines, and project templates to streamline community development.
+
+---
+
+## License & security
+
+- Licensed under the [MIT License](LICENSE).
+- For security disclosures and the threat model, see [`SECURITY.md`](SECURITY.md).
+- Issues and PRs welcome — this is a young project and feedback is the fastest way to improve it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,101 @@
+# Security policy
+
+anon-proxy is a privacy tool. The whole point is preventing PII from leaking to
+upstream LLM APIs. Bugs that defeat that goal are the most important class of
+issue this project has.
+
+## Reporting a vulnerability
+
+**Do not file a public GitHub issue for security bugs.** A public issue with a
+working exploit invites the same data leaks anon-proxy is supposed to prevent.
+
+Instead, email the maintainer privately. Include:
+
+- A short description of what the bug allows.
+- Steps to reproduce, ideally with a minimal input (a prompt, a tool call, etc.)
+  that demonstrates PII leaking past the masker.
+- The detector configuration you were running (default model, any `--patterns`
+  or `--merge-gap-file` overrides, `--backend` setting).
+- Your view on severity (does it leak in normal use, or only with a contrived
+  setup?).
+
+You should expect an acknowledgement within a few days. Once a fix is ready
+and shipped, the issue can be disclosed publicly with credit.
+
+## Threat model
+
+### In scope
+
+Scope is limited to **the providers anon-proxy ships an adapter for** —
+currently the Anthropic Messages API (`/anthropic`) and the OpenAI
+Chat Completions API (`/openai`). Custom upstreams added via
+`--extra-upstream` are in scope only when paired with one of the supported
+adapter types (`adapter=anthropic` or `adapter=openai`); other routings
+will pass raw bytes through.
+
+- **Outbound request bodies on supported adapters** — anything that goes
+  from your client through a supported adapter to the upstream API. Names,
+  emails, phone numbers, addresses, and other configured PII categories
+  should be replaced with stable placeholders before the bytes leave the
+  proxy process.
+- **Inbound response bodies on supported adapters** — placeholders the
+  model emits should be rewritten to the original values before the
+  response reaches your client, so the client sees a coherent conversation.
+- **Multi-turn coherence** — the same input value should map to the same
+  placeholder on every turn within a session, so the model can reason about
+  the same entity over time.
+
+### Out of scope
+
+These are not bugs anon-proxy claims to defend against:
+
+- **A malicious local user.** anon-proxy runs on your machine and trusts the
+  user running it. Anyone with shell access to the host can read the in-memory
+  store, inspect uvicorn logs, or just set `--debug`.
+- **Side channels.** Request length, latency, and traffic shape are not
+  obscured. An upstream provider observing many proxied requests can still
+  infer aggregate properties.
+- **The system prompt and tool definitions.** These are passed through
+  unmasked because they typically contain static instructions and schemas, not
+  user PII. If your system prompt contains PII, treat that as a misuse — put
+  the PII in user/assistant messages where the masker runs.
+- **Extended-thinking blocks.** Anthropic's extended-thinking blocks carry
+  cryptographic signatures that break if the contents are rewritten, so they
+  are passed through unchanged. Don't put PII in fields a model is going to
+  emit as signed thinking.
+- **The detector model itself.** anon-proxy uses the
+  [openai/privacy-filter](https://huggingface.co/openai/privacy-filter) model.
+  False negatives in that model are detector quality bugs, not anon-proxy
+  vulnerabilities — but if you find a class of input that systematically
+  bypasses masking, please report it; we may be able to mitigate it via
+  chunking, regex augmentation, or merge-gap tuning.
+
+### Known limitations
+
+These are documented gaps rather than secrets. Please do *not* file private
+security reports for these — they are open trade-offs:
+
+- **Clue-less PII can be missed.** Bare phone numbers, isolated tokens, or
+  out-of-context identifiers may evade the ML detector. Promote regex
+  detectors via `--patterns` to close gaps you observe.
+- **Span fragmentation.** A single entity may be split into adjacent spans
+  ("Jean" + "Luc"). Adjust `--merge-gap-file` per label.
+- **Chunk boundaries.** Long inputs are chunked at `--chunk-size`; PII
+  straddling a boundary may lose context. Raise `--chunk-size` if you have
+  the VRAM.
+- **Tool results that depend on literal values.** If a tool consumes a literal
+  email or ID and round-trips it back, the masked placeholder may break the
+  tool's contract. Configure `--patterns` carefully or skip masking for the
+  affected tool.
+
+## Operational guidance
+
+If you run anon-proxy on multi-user hardware or expose it on a LAN
+(`--host 0.0.0.0`), you are widening the trust boundary beyond a single user.
+The proxy has no authentication of its own — it forwards client auth headers
+unchanged. Put your own auth in front of it (firewall, mTLS, an
+authenticating reverse proxy) before exposing it beyond `127.0.0.1`.
+
+When in doubt, run with `--debug` once on representative traffic and read the
+diffs. Anything you see leaving the proxy unmasked, the upstream provider sees
+too.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,16 @@ issue this project has.
 **Do not file a public GitHub issue for security bugs.** A public issue with a
 working exploit invites the same data leaks anon-proxy is supposed to prevent.
 
-Instead, email the maintainer privately. Include:
+Instead, use GitHub's [Private Vulnerability Reporting][pvr] to send the
+maintainers a private advisory:
+
+1. Go to the [Security tab](https://github.com/KevinXuxuxu/anon_proxy/security)
+   of this repository.
+2. Click **Report a vulnerability** (or open
+   <https://github.com/KevinXuxuxu/anon_proxy/security/advisories/new> directly).
+3. Fill in the advisory form.
+
+Please include:
 
 - A short description of what the bug allows.
 - Steps to reproduce, ideally with a minimal input (a prompt, a tool call, etc.)
@@ -20,7 +29,9 @@ Instead, email the maintainer privately. Include:
   setup?).
 
 You should expect an acknowledgement within a few days. Once a fix is ready
-and shipped, the issue can be disclosed publicly with credit.
+and shipped, the advisory can be published with credit.
+
+[pvr]: https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability
 
 ## Threat model
 


### PR DESCRIPTION
## Summary

A docs-only PR aimed at making the project easier to discover, easier to evaluate at a glance, and easier to trust. No code touched.

Three commits, easy to cherry-pick or drop independently:

1. **README revamp** — value-led tagline; badges; "Who is this for?" personas; "Why not just use X?" comparison table (Presidio, AWS Comprehend, GCP DLP, LiteLLM); FAQ section (Q&A subheadings index well for LLM agents and humans). All existing technical content preserved verbatim.
2. **LICENSE (MIT)** — the repo previously had no license, which technically makes it non-redistributable. Picked MIT as the most common choice for OSS dev tooling. **Maintainer: please confirm or swap this commit for your preferred license — that's your call, not mine.**
3. **SECURITY.md** — threat model + private disclosure policy. Covers in-scope guarantees, out-of-scope items (system prompt, extended-thinking blocks, side channels, malicious local user), and known false-negative modes. Important for a privacy tool both as a trust signal and as a triage surface.

## Why

For an open source privacy tool, a few of the highest-leverage things a casual visitor wants to know in the first 30 seconds:

- *Who is this for? Is it for me?*
- *How is this different from Presidio / AWS Comprehend / LiteLLM?*
- *What does it actually defend against, and what doesn't it?*
- *Can I legally use it?*

The current README answers the *how* well but not the *why* / *who* / *vs.what*. This PR addresses that without churning the technical sections.

## What didn't change

- All server flag tables, env-var docs, Claude Code setup steps, configuration files, telemetry section, and roadmap are preserved as-is.
- No code changes, no test changes, no CI changes.

## Suggestions for follow-up (not in this PR)

If you want to lean further into discoverability, the cheap wins from here are:
- Set the GitHub repo `description` and `topics` (`llm`, `claude`, `privacy`, `pii`, `gdpr`, `hipaa`, `anthropic`, `proxy`, `claude-code`).
- Set a social preview image (Settings → Social preview).
- Publish to PyPI as `anon-proxy` (biggest install-friction reduction).
- Submit to awesome-claude / awesome-llm / awesome-privacy / awesome-selfhosted lists.
- Show HN once you're comfortable with the fit.

Happy to do any of these as separate PRs if useful.

## Test plan

Docs-only — no test surface. Manually verified:
- [x] README renders cleanly (markdown, tables, code blocks)
- [x] Internal anchor links resolve (`#using-with-claude-code`, `#next-steps--roadmap`)
- [x] No technical content removed from the original README
- [x] LICENSE is the standard MIT text
- [x] SECURITY.md cross-links from README

🤖 Generated with [Claude Code](https://claude.com/claude-code)