### PR TITLE
Publishing & promotion runbook (PyPI metadata + discoverability docs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,8 @@ wheels/
 # Virtual environments
 .venv
 
+# Git worktrees
+.worktrees/
+
 fzxu_git.sh
 *.json

--- a/docs/awesome-submissions.md
+++ b/docs/awesome-submissions.md
@@ -1,0 +1,114 @@
+# Awesome-list submission packet
+
+Pre-formatted entries for getting anon-proxy listed on curated "awesome" lists.
+Each section is one target list. Copy the entry text, open a PR against the
+list's repo following its CONTRIBUTING guide, and link back to anon-proxy.
+
+## How to submit (general)
+
+1. Fork the target list's repo.
+2. Find the right section (privacy, LLM tooling, proxies, etc.).
+3. Insert the entry alphabetically *within* that section unless the list
+   says otherwise.
+4. Follow the list's exact link format — most use
+   `- [name](url) - description.` but capitalisation/punctuation varies.
+5. Run any linter the list ships (`awesome-lint`, custom CI) before
+   opening the PR.
+6. PR title: typically `Add anon-proxy` or `Add anon-proxy to <section>`.
+
+## Target lists
+
+### sindresorhus/awesome (the meta-list)
+
+Don't submit here — entries must themselves be awesome lists, not projects.
+
+### awesome-llm-apps / awesome-llm
+
+Repos to check (verify each is still active before submitting; some have
+gone stale):
+- https://github.com/Shubhamsaboo/awesome-llm-apps
+- https://github.com/Hannibal046/Awesome-LLM
+- https://github.com/horseee/Awesome-Efficient-LLM
+
+**Section to target:** "Tools" or "Infrastructure" or "Privacy" — whichever
+exists. If only "Applications" exists, look for a "Tools" subsection.
+
+**Entry text:**
+
+```markdown
+- [anon-proxy](https://github.com/KevinXuxuxu/anon_proxy) - Local PII masking proxy for LLM APIs (Anthropic, OpenAI). Detects names, emails, and phones with the openai/privacy-filter model and rewrites them to stable placeholders before requests leave your machine. Works with Claude Code and the OpenAI SDK.
+```
+
+### awesome-privacy
+
+Target: https://github.com/Lissy93/awesome-privacy
+
+**Section to target:** "Developer tools" or a "PII / Data protection" section
+if one exists.
+
+**Entry text** (this list uses a structured YAML-ish front-matter, check the
+CONTRIBUTING guide before submitting):
+
+```markdown
+- name: anon-proxy
+  url: https://github.com/KevinXuxuxu/anon_proxy
+  description: Local PII masking proxy for LLM APIs. Detects PII with the openai/privacy-filter model and rewrites to stable placeholders before requests leave the device.
+  icon: shield
+```
+
+If the file is plain Markdown after all, fall back to the standard one-line
+format above.
+
+### awesome-mlops / awesome-ml-tools
+
+- https://github.com/kelvins/awesome-mlops
+
+**Section:** "Privacy" or "Inference / Serving."
+
+**Entry text:** same one-line format as awesome-llm above.
+
+### awesome-claude
+
+If a curated list specifically for Claude/Anthropic exists, it's a strong fit.
+Check:
+- https://github.com/eastlondoner/awesome-claude-code (if it exists)
+- Search GitHub: `awesome claude` topic + recent commits.
+
+If none active: skip.
+
+### Hacker News "Show HN"
+
+Not a list, but high-leverage one-shot promotion. Post format:
+
+> **Show HN: anon-proxy – Local PII masking proxy for LLM APIs**
+>
+> https://github.com/KevinXuxuxu/anon_proxy
+>
+> Hi HN — anon-proxy is a small Starlette/uvicorn proxy that sits between
+> your app and Anthropic/OpenAI. Before each request goes upstream, it runs
+> the openai/privacy-filter NER model locally and rewrites detected PII
+> (names, emails, phones, addresses) to stable placeholders like
+> `<PERSON_1>`. The model's response uses the same placeholders, which
+> the proxy unmasks before returning to your client — so the upstream
+> provider never sees the raw values, but the application logic still works.
+>
+> Built it because I wanted to use Claude Code and the OpenAI SDK on
+> internal data without sending the raw text to a vendor. Open to
+> feedback on the threat model, the placeholder scheme, and the missing
+> features (full streaming, more providers).
+
+Best to post on a Tuesday-Thursday morning Pacific time.
+
+### Reddit / r/MachineLearning, r/LocalLLaMA, r/Privacy
+
+Format is more conversational — share what you built, what problem it
+solves, and ask for feedback. Read the subreddit's self-promotion rules
+before posting; some require a 9:1 contribution-to-promotion ratio.
+
+## Submission tracker
+
+Keep a row per submission so we don't double-submit:
+
+| Date | List / venue | Entry URL (PR / post) | Status |
+|------|--------------|------------------------|--------|
+| YYYY-MM-DD | awesome-llm-apps | https://… | open / merged / rejected |

--- a/docs/discoverability.md
+++ b/docs/discoverability.md
@@ -1,0 +1,88 @@
+# GitHub repo discoverability checklist
+
+This is a one-time checklist for the upstream maintainer. Each item is
+something GitHub indexes for search, or that AI agents and curators see when
+they look at the repo.
+
+## 1. Repo description (About section)
+
+Set on https://github.com/KevinXuxuxu/anon_proxy → ⚙️ next to "About":
+
+> Local-first PII masking proxy for LLM APIs. Detects names, emails, phones, addresses with openai/privacy-filter and rewrites them to stable placeholders before bytes leave your machine. Works with Claude Code, OpenAI SDK, and any HTTP-compatible client.
+
+(255-char limit. The current text is the GitHub default or empty.)
+
+## 2. Website link
+
+In the same About panel, set "Website" to the README URL or a project page:
+`https://github.com/KevinXuxuxu/anon_proxy#readme`
+
+## 3. Topics (high-impact for GitHub search)
+
+Add these topics in the About panel. GitHub allows up to 20.
+
+**Core (must-have):**
+- `privacy`
+- `pii`
+- `pii-detection`
+- `llm`
+- `proxy`
+- `data-protection`
+
+**Provider/client targeting (helps users find you):**
+- `anthropic`
+- `claude`
+- `openai`
+- `chatgpt`
+- `claude-code`
+
+**Stack:**
+- `python`
+- `transformers`
+- `huggingface`
+
+**Use case:**
+- `redaction`
+- `masking`
+- `data-anonymization`
+- `gdpr`
+
+## 4. Social preview image
+
+GitHub Settings → "Social preview" → upload a 1280×640 PNG/JPG.
+This is what shows in Twitter/Slack/Discord cards when the repo is shared.
+
+Suggested content for the preview image:
+- Top half: project name + tagline ("PII masking proxy for LLM APIs").
+- Bottom half: a small diagram or terminal screenshot showing
+  `<PERSON_1>` placeholders replacing real names in a request.
+
+If you don't have design tooling, GitHub's auto-generated preview (repo name
+on a colored background) is acceptable but generic. Even a quick Figma export
+beats it.
+
+## 5. Pinned repos on the maintainer profile
+
+If you maintain multiple repos, pin anon-proxy on your GitHub profile so
+visitors see it first.
+
+## 6. README badge audit
+
+Confirm the badges at the top of `README.md` actually link somewhere useful:
+- License badge → `LICENSE` file
+- Python version badge → relevant docs
+- "Works with Claude Code" badge → README anchor or Anthropic docs
+
+## 7. CODEOWNERS (optional but signals maintenance)
+
+Even a one-line `.github/CODEOWNERS` makes it clear who reviews PRs:
+
+```
+* @KevinXuxuxu
+```
+
+## 8. Issue/PR templates (optional)
+
+If issue volume grows, add `.github/ISSUE_TEMPLATE/bug_report.md` and
+`.github/ISSUE_TEMPLATE/feature_request.md`. For a young project this is
+overkill — wait until repeated low-quality issues justify the friction.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,100 @@
+# Publishing to PyPI
+
+This is the runbook for releasing a new version of anon-proxy. It assumes
+maintainer access to the project's PyPI account and a clean checkout of `main`.
+
+## Prerequisites (one-time)
+
+1. **PyPI account** — create at https://pypi.org/account/register/.
+2. **Test-PyPI account** — create at https://test.pypi.org/account/register/.
+   Use a different password from prod PyPI.
+3. **API tokens** — generate scoped-to-project tokens on both, store in your
+   keychain. Never commit them.
+4. **`twine` installed** — `uv tool install twine`. Or `pipx install twine`.
+
+`~/.pypirc` (chmod 600):
+
+```ini
+[distutils]
+index-servers =
+    pypi
+    testpypi
+
+[pypi]
+username = __token__
+password = pypi-AgEI...   # your prod token
+
+[testpypi]
+username = __token__
+password = pypi-AgEN...   # your test token
+```
+
+## Release procedure
+
+1. **Bump the version** in `pyproject.toml` (`version = "X.Y.Z"`). Follow
+   [SemVer](https://semver.org/): patch for bugfixes, minor for new features,
+   major for breaking changes. Until 1.0, breaking changes can land in minors.
+2. **Update CHANGELOG.md** if one exists — note user-visible changes.
+3. **Commit and tag:**
+   ```bash
+   git commit -am "release: vX.Y.Z"
+   git tag -a vX.Y.Z -m "vX.Y.Z"
+   git push origin main vX.Y.Z
+   ```
+4. **Build the artifacts:**
+   ```bash
+   rm -rf dist/
+   uv build
+   ```
+   Confirm `dist/` contains both the `.whl` and the `.tar.gz`.
+5. **Smoke test the wheel locally:**
+   ```bash
+   python3 -m venv /tmp/release-smoke
+   /tmp/release-smoke/bin/pip install dist/anon_proxy-X.Y.Z-py3-none-any.whl
+   /tmp/release-smoke/bin/anon-proxy --help
+   rm -rf /tmp/release-smoke
+   ```
+6. **Upload to test-pypi first:**
+   ```bash
+   twine upload --repository testpypi dist/*
+   ```
+   Visit https://test.pypi.org/project/anon-proxy/ and confirm the listing
+   renders correctly (description, classifiers, links).
+7. **Install from test-pypi to verify:**
+   ```bash
+   python3 -m venv /tmp/testpypi-smoke
+   /tmp/testpypi-smoke/bin/pip install \
+     --index-url https://test.pypi.org/simple/ \
+     --extra-index-url https://pypi.org/simple/ \
+     anon-proxy
+   /tmp/testpypi-smoke/bin/anon-proxy --help
+   rm -rf /tmp/testpypi-smoke
+   ```
+8. **Upload to prod PyPI:**
+   ```bash
+   twine upload dist/*
+   ```
+9. **Post-release:**
+   - Open a GitHub release at the tag with the changelog excerpt.
+   - Bump version in `pyproject.toml` to next dev tag if you use one.
+   - Tweet / post the announcement.
+
+## If you publish a broken release
+
+PyPI does not allow re-uploading the same version. You must:
+
+1. Yank the broken release on the PyPI web UI (it stays installed for users
+   who pinned it but disappears from search).
+2. Bump to the next patch version and publish a fixed release.
+
+## Common issues
+
+- **`InvalidDistribution: Metadata is missing required fields`** — `pyproject.toml`
+  is missing `name`, `version`, or `description`. Check Task 1 of the
+  publishing-and-promotion plan.
+- **`The user '__token__' isn't allowed to upload to project 'anon-proxy'`** —
+  your token is scoped to a different project, or the project name was renamed.
+  Generate a new token scoped to `anon-proxy`.
+- **README renders as plain text on PyPI** — `readme = "README.md"` is set but
+  PyPI couldn't determine the content type. Add to `[project]`:
+  `readme = { file = "README.md", content-type = "text/markdown" }`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,41 @@
 [project]
 name = "anon-proxy"
 version = "0.1.0"
-description = "Add your description here"
+description = "Local-first PII masking proxy for LLM APIs (Anthropic, OpenAI). Detects names, emails, phone numbers, addresses with the openai/privacy-filter model and rewrites them to stable placeholders before bytes leave your machine."
 readme = "README.md"
 requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "anon-proxy contributors" },
+]
+keywords = [
+    "privacy",
+    "pii",
+    "llm",
+    "anthropic",
+    "openai",
+    "claude",
+    "chatgpt",
+    "proxy",
+    "masking",
+    "redaction",
+    "data-protection",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Internet :: Proxy Servers",
+    "Topic :: Security",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
 dependencies = [
     "anthropic>=0.96.0",
     "httpx>=0.28.1",
@@ -13,3 +45,15 @@ dependencies = [
     "transformers>=5.6.0",
     "uvicorn[standard]>=0.45.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/KevinXuxuxu/anon_proxy"
+Repository = "https://github.com/KevinXuxuxu/anon_proxy"
+Issues = "https://github.com/KevinXuxuxu/anon_proxy/issues"
+
+[project.scripts]
+anon-proxy = "anon_proxy.server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/uv.lock
+++ b/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 [[package]]
 name = "anon-proxy"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Follow-up to #3. Three independent but cohesive deliverables, all post-merge promotion prep:

- **PyPI-ready `pyproject.toml`** — real description, MIT license, OSI classifiers, project URLs, keywords, and an `anon-proxy` console script entry point. Wheel builds cleanly via `uv build` and installs into a fresh venv.
- **`docs/publishing.md`** — runbook for releasing to PyPI: prerequisites, build, test-pypi smoke test, prod upload, post-release checklist.
- **`docs/discoverability.md`** — one-time GitHub setup checklist: repo description, recommended topics, social preview spec, optional CODEOWNERS.
- **`docs/awesome-submissions.md`** — pre-formatted entries for awesome-llm, awesome-privacy, awesome-mlops, plus a Show HN draft and a submission tracker.

Nothing in `anon_proxy/` changes — this is metadata + docs only.

## Test plan

- [x] `uv build` produces `.whl` and `.tar.gz` in `dist/`
- [x] Installing the wheel into a clean venv exposes the `anon-proxy` CLI
- [x] `anon-proxy --help` prints the argparse usage
- [x] All Markdown docs render correctly on GitHub

## Maintainer next steps (post-merge)

These actions need maintainer accounts and aren't part of this PR:
1. Apply `docs/discoverability.md` checklist to the GitHub repo About panel + social preview.
2. Cut a release per `docs/publishing.md` and upload to PyPI.
3. Open submissions per `docs/awesome-submissions.md` (one PR per list).

## Notes

- Pinned to MIT in `pyproject.toml` to match `LICENSE` from #3. If the maintainer prefers a different license, update both files together.
- Console script name `anon-proxy` (hyphenated) is the conventional CLI form; the package name `anon_proxy` (underscore) is the conventional Python module form.