### PR TITLE
feat: named pipeline stages (1/4 — splits #5)

### DIFF
--- a/anon_proxy/masker.py
+++ b/anon_proxy/masker.py
@@ -4,6 +4,12 @@ import re
 from typing import Callable, Protocol
 
 from anon_proxy.mapping import PIIStore
+from anon_proxy.pipeline import (
+    AttributedSpan,
+    GreedyLongerWins,
+    OverlapPolicy,
+    ResolveResult,
+)
 from anon_proxy.privacy_filter import PIIEntity, PrivacyFilter
 
 
@@ -14,26 +20,23 @@ class Detector(Protocol):
 # Patterns for content that should never be masked (non-user PII content)
 _SKIP_MASK_PATTERNS = [
     # Claude Code system-reminder blocks - contain tool definitions, skills list, etc.
-    re.compile(r'^\s*<system-reminder>', re.MULTILINE),
-    # Tool result blocks that are purely structural (e.g., file listings, tool outputs)
-    # These can be extended as needed
+    re.compile(r"^\s*<system-reminder>", re.MULTILINE),
 ]
 
 
 class Masker:
-    """Composes PrivacyFilter + PIIStore to mask outgoing text and unmask LLM replies.
+    """Masker runs the user-output pipeline: detect_ml → detect_user → resolve → replace.
 
-    One Masker instance per conversation: the store accumulates entities across
-    turns so the same PII always gets the same placeholder.
+    Stages are named methods (`_detect_ml`, `_detect_user`, `_resolve`,
+    `_replace`) so each one has a single responsibility and can be tested or
+    swapped in isolation.
 
-    `extra_detectors` is a list of objects with a `detect(text) -> list[PIIEntity]`
-    method whose spans are merged into the primary filter's output. Overlapping
-    spans from different detectors are resolved by preferring the longer span.
+    `extra_detectors` participate in resolution and affect masked output.
 
     Performance optimizations:
-    - Caches detection results by content hash to avoid re-scanning identical text
+    - Caches mask results by content hash to skip re-scanning identical text
     - Skips masking for known non-PII patterns (e.g., system-reminders)
-    - Early-return if content already contains only placeholders (no new PII)
+    - Early-return on empty resolve result
     """
 
     def __init__(
@@ -41,74 +44,76 @@ class Masker:
         filter: PrivacyFilter | None = None,
         store: PIIStore | None = None,
         extra_detectors: list[Detector] | None = None,
+        overlap_policy: OverlapPolicy | None = None,
         skip_patterns: list[re.Pattern] | None = None,
         cache_size: int = 256,
     ) -> None:
         self._filter = filter or PrivacyFilter()
         self._store = store or PIIStore()
         self._extra: list[Detector] = list(extra_detectors or [])
+        self._policy: OverlapPolicy = overlap_policy or GreedyLongerWins()
         self._skip_patterns = skip_patterns or _SKIP_MASK_PATTERNS
         self._cache_size = cache_size
-        # Cache: content_hash -> (entities_text, masked_text)
-        self._cache: dict[str, tuple[list[PIIEntity], str]] = {}
+        self._cache: dict[str, str] = {}
 
     @property
     def store(self) -> PIIStore:
         return self._store
 
     def mask(self, text: str) -> str:
-        # Fast path: check if this text matches any skip pattern
+        # Skip-pattern fast path: text we explicitly do not mask.
         for pattern in self._skip_patterns:
             if pattern.search(text):
-                return text  # Skip masking entirely
+                return text
 
-        # Check cache
+        # Cache fast path: identical input → identical output.
         content_hash = _hash_content(text)
-        if cached := self._cache.get(content_hash):
-            return cached[1]
+        if (cached := self._cache.get(content_hash)) is not None:
+            return cached
 
-        # Detect entities
-        entities: list[PIIEntity] = list(self._filter.detect(text))
-        for detector in self._extra:
-            entities.extend(detector.detect(text))
-        entities = _resolve_overlaps(entities)
-
-        # Early return if no entities found
-        if not entities:
-            self._cache_result(content_hash, [], text)
+        ml_spans = self._detect_ml(text)
+        user_spans = self._detect_user(text)
+        result = self._resolve(ml_spans + user_spans)
+        if not result.kept:
+            self._cache_result(content_hash, text)
             return text
-
-        # Replace right-to-left so earlier spans' offsets stay valid.
-        masked = text
-        for e in sorted(entities, key=lambda x: x.start, reverse=True):
-            token = self._store.get_or_create(e.label, e.text).token
-            masked = masked[: e.start] + token + masked[e.end :]
-
-        self._cache_result(content_hash, entities, masked)
+        masked = self._replace(text, result.kept)
+        self._cache_result(content_hash, masked)
         return masked
 
-    def _cache_result(self, content_hash: str, entities: list[PIIEntity], masked: str) -> None:
-        """Cache a detection result, evicting oldest if cache is full."""
+    def _detect_ml(self, text: str) -> list[AttributedSpan]:
+        return [AttributedSpan(entity=e, source="ml") for e in self._filter.detect(text)]
+
+    def _detect_user(self, text: str) -> list[AttributedSpan]:
+        out: list[AttributedSpan] = []
+        for d in self._extra:
+            out.extend(AttributedSpan(entity=e, source="user_regex") for e in d.detect(text))
+        return out
+
+    def _resolve(self, spans: list[AttributedSpan]) -> ResolveResult:
+        return self._policy.resolve(spans)
+
+    def _replace(self, text: str, kept: list[AttributedSpan]) -> str:
+        # Right-to-left so earlier offsets stay valid.
+        for s in sorted(kept, key=lambda x: x.start, reverse=True):
+            token = self._store.get_or_create(s.label, s.entity.text).token
+            text = text[: s.start] + token + text[s.end :]
+        return text
+
+    def _cache_result(self, content_hash: str, masked: str) -> None:
+        """Cache a mask result, evicting oldest if cache is full (FIFO)."""
         if len(self._cache) >= self._cache_size:
-            # Simple FIFO eviction - remove first item
             self._cache.pop(next(iter(self._cache)))
-        self._cache[content_hash] = (entities, masked)
+        self._cache[content_hash] = masked
 
     def unmask(self, text: str) -> str:
         return self._sub(text, lambda s: s)
 
     def unmask_json(self, text: str) -> str:
-        """Unmask tokens sitting inside a JSON string context.
-
-        Replacements are JSON-escaped so an original containing `"`, `\\`, or
-        control chars doesn't break the surrounding JSON. Use this for raw
-        JSON fragments like Anthropic's `input_json_delta.partial_json` where
-        the unmasked text flows through an unparsed string.
-        """
+        """Unmask tokens inside a JSON string context (escapes the unmasked value)."""
         return self._sub(text, lambda s: json.dumps(s)[1:-1])
 
     def _sub(self, text: str, transform: Callable[[str], str]) -> str:
-        """Substitute placeholder tokens with their original values."""
         tokens = self._store.tokens()
         if not tokens:
             return text
@@ -124,37 +129,10 @@ class Masker:
         return pattern.sub(repl, text)
 
 
-def _resolve_overlaps(entities: list[PIIEntity]) -> list[PIIEntity]:
-    """Keep a non-overlapping subset of spans.
-
-    Greedy: sort by (start, -length, -score) so earlier and longer spans land first.
-    Walk left-to-right; when a span overlaps the last kept, replace only if the
-    new one is strictly longer (ties: higher score wins). Touching spans at
-    `prev.end == next.start` do not overlap.
-    """
-    if not entities:
-        return entities
-    ordered = sorted(
-        entities,
-        key=lambda e: (e.start, -(e.end - e.start), -e.score, e.label),
-    )
-    kept: list[PIIEntity] = []
-    for e in ordered:
-        if kept and e.start < kept[-1].end:
-            prev = kept[-1]
-            prev_len = prev.end - prev.start
-            cur_len = e.end - e.start
-            if cur_len > prev_len or (cur_len == prev_len and e.score > prev.score):
-                kept[-1] = e
-            continue
-        kept.append(e)
-    return kept
-
-
 def _hash_content(text: str) -> str:
     """Hash content for caching detection results.
 
-    Uses SHA256 truncated to 12 chars (collision-resistant enough for cache keys,
-    compact enough to be memory-efficient).
+    SHA256 truncated to 12 chars: collision-resistant enough for cache keys,
+    compact enough to be memory-efficient.
     """
     return hashlib.sha256(text.encode("utf-8")).hexdigest()[:12]

--- a/anon_proxy/pipeline.py
+++ b/anon_proxy/pipeline.py
@@ -1,0 +1,112 @@
+"""Named PII pipeline stages: detect → resolve → replace.
+
+Gives every pipeline stage a name and an interface so the three architectural
+questions (passes, range interaction, chunking) have named code to point at.
+
+`AttributedSpan` tags every detected span with the detector that emitted it.
+`OverlapPolicy` is the seam where range interaction lives.
+`OverlapEvent` is the data shape downstream observers can read to record
+kept-vs-dropped decisions, without scattering instrumentation through the
+resolver.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+from anon_proxy.privacy_filter import PIIEntity
+
+Source = Literal["ml", "user_regex", "baseline"]
+_VALID_SOURCES: frozenset[str] = frozenset({"ml", "user_regex", "baseline"})
+
+Reason = Literal["overlap_longer", "overlap_score_tie"]
+
+
+@dataclass(frozen=True)
+class AttributedSpan:
+    """A detected span plus the detector that produced it."""
+
+    entity: PIIEntity
+    source: Source
+
+    def __post_init__(self) -> None:
+        if self.source not in _VALID_SOURCES:
+            raise ValueError(
+                f"AttributedSpan.source must be one of {sorted(_VALID_SOURCES)}, got {self.source!r}"
+            )
+
+    @property
+    def start(self) -> int:
+        return self.entity.start
+
+    @property
+    def end(self) -> int:
+        return self.entity.end
+
+    @property
+    def label(self) -> str:
+        return self.entity.label
+
+    @property
+    def length(self) -> int:
+        return self.entity.end - self.entity.start
+
+
+@dataclass(frozen=True)
+class OverlapEvent:
+    """Records that `winner` beat `loser` during overlap resolution."""
+
+    winner: AttributedSpan
+    loser: AttributedSpan
+    reason: Reason
+
+
+@dataclass(frozen=True)
+class ResolveResult:
+    """Output of an `OverlapPolicy.resolve` call."""
+
+    kept: list[AttributedSpan]
+    events: list[OverlapEvent]
+
+
+class OverlapPolicy(Protocol):
+    def resolve(self, spans: list[AttributedSpan]) -> ResolveResult: ...
+
+
+class GreedyLongerWins:
+    """Sort by (start asc, length desc, score desc, label); walk left-to-right.
+
+    On overlap with the last-kept span, replace iff the new span is strictly
+    longer; on length tie, replace iff strictly higher score. Touching spans
+    (`prev.end == next.start`) are treated as disjoint. Behavior matches the
+    pre-refactor `masker._resolve_overlaps` exactly.
+    """
+
+    def resolve(self, spans: list[AttributedSpan]) -> ResolveResult:
+        if not spans:
+            return ResolveResult(kept=[], events=[])
+
+        ordered = sorted(
+            spans,
+            key=lambda s: (s.start, -s.length, -s.entity.score, s.label),
+        )
+        kept: list[AttributedSpan] = []
+        events: list[OverlapEvent] = []
+        for cand in ordered:
+            if kept and cand.start < kept[-1].end:
+                prev = kept[-1]
+                if cand.length > prev.length:
+                    events.append(OverlapEvent(winner=cand, loser=prev, reason="overlap_longer"))
+                    kept[-1] = cand
+                elif cand.length == prev.length:
+                    if cand.entity.score > prev.entity.score:
+                        events.append(OverlapEvent(winner=cand, loser=prev, reason="overlap_score_tie"))
+                        kept[-1] = cand
+                    else:
+                        events.append(OverlapEvent(winner=prev, loser=cand, reason="overlap_score_tie"))
+                else:
+                    events.append(OverlapEvent(winner=prev, loser=cand, reason="overlap_longer"))
+                continue
+            kept.append(cand)
+        return ResolveResult(kept=kept, events=events)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,8 @@ anon-proxy = "anon_proxy.server:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+"""Shared pytest fixtures."""
+
+from __future__ import annotations

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,82 @@
+from anon_proxy.pipeline import AttributedSpan, GreedyLongerWins, OverlapEvent, ResolveResult
+from anon_proxy.privacy_filter import PIIEntity
+
+
+def _entity(label: str, start: int, end: int, score: float = 1.0) -> PIIEntity:
+    return PIIEntity(label=label, text="x" * (end - start), start=start, end=end, score=score)
+
+
+def _aspan(label: str, start: int, end: int, source: str = "ml", score: float = 1.0):
+    return AttributedSpan(entity=_entity(label, start, end, score), source=source)
+
+
+def test_attributed_span_carries_source():
+    span = AttributedSpan(entity=_entity("EMAIL", 0, 5), source="ml")
+    assert span.source == "ml"
+    assert span.entity.label == "EMAIL"
+
+
+def test_attributed_span_source_must_be_known():
+    import pytest
+    with pytest.raises(ValueError):
+        AttributedSpan(entity=_entity("EMAIL", 0, 5), source="bogus")
+
+
+def test_overlap_event_records_winner_and_loser():
+    w = AttributedSpan(entity=_entity("EMAIL", 0, 10), source="ml")
+    l = AttributedSpan(entity=_entity("EMAIL", 0, 5), source="user_regex")
+    ev = OverlapEvent(winner=w, loser=l, reason="overlap_longer")
+    assert ev.winner.source == "ml"
+    assert ev.loser.source == "user_regex"
+    assert ev.reason == "overlap_longer"
+
+
+def test_resolve_result_holds_kept_and_events():
+    span = AttributedSpan(entity=_entity("EMAIL", 0, 5), source="ml")
+    r = ResolveResult(kept=[span], events=[])
+    assert r.kept == [span]
+    assert r.events == []
+
+
+def test_greedy_keeps_disjoint_spans():
+    a = _aspan("EMAIL", 0, 5)
+    b = _aspan("PHONE", 10, 20)
+    r = GreedyLongerWins().resolve([b, a])
+    assert [s.start for s in r.kept] == [0, 10]
+    assert r.events == []
+
+
+def test_greedy_treats_touching_as_disjoint():
+    a = _aspan("EMAIL", 0, 5)
+    b = _aspan("EMAIL", 5, 10)
+    r = GreedyLongerWins().resolve([a, b])
+    assert len(r.kept) == 2
+    assert r.events == []
+
+
+def test_greedy_longer_wins_records_event():
+    short = _aspan("EMAIL", 0, 5, source="user_regex")
+    long_ = _aspan("EMAIL", 0, 10, source="ml")
+    r = GreedyLongerWins().resolve([short, long_])
+    assert [s.start for s in r.kept] == [0]
+    assert r.kept[0].length == 10
+    assert len(r.events) == 1
+    assert r.events[0].winner.source == "ml"
+    assert r.events[0].loser.source == "user_regex"
+    assert r.events[0].reason == "overlap_longer"
+
+
+def test_greedy_score_breaks_length_tie():
+    ml = _aspan("EMAIL", 0, 5, source="ml", score=0.7)
+    rx = _aspan("EMAIL", 0, 5, source="user_regex", score=1.0)
+    r = GreedyLongerWins().resolve([ml, rx])
+    assert r.kept[0].source == "user_regex"
+    assert r.events[0].winner.source == "user_regex"
+    assert r.events[0].loser.source == "ml"
+    assert r.events[0].reason == "overlap_score_tie"
+
+
+def test_greedy_empty_input():
+    r = GreedyLongerWins().resolve([])
+    assert r.kept == []
+    assert r.events == []

--- a/uv.lock
+++ b/uv.lock
@@ -38,6 +38,11 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.96.0" },
@@ -48,6 +53,9 @@ requires-dist = [
     { name = "transformers", specifier = ">=5.6.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.45.0" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "anthropic"
@@ -372,6 +380,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -934,6 +951,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -1083,6 +1109,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -1398,6 +1442,60 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/46/cd/e4851401f3d8f6f45d8480262ab6a5c8cb9c4302a790a35aa14eeed6d2fd/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e10bf9113d209be7cd046d40fbabbaf3278ff6d18eb4da4c500443185dc1896c", size = 3161308, upload-time = "2026-01-05T10:40:40.737Z" },
     { url = "https://files.pythonhosted.org/packages/6f/6e/55553992a89982cd12d4a66dddb5e02126c58677ea3931efcbe601d419db/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64d94e84f6660764e64e7e0b22baa72f6cd942279fdbb21d46abd70d179f0195", size = 3718964, upload-time = "2026-01-05T10:40:46.56Z" },
     { url = "https://files.pythonhosted.org/packages/59/8c/b1c87148aa15e099243ec9f0cf9d0e970cc2234c3257d558c25a2c5304e6/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f01a9c019878532f98927d2bacb79bbb404b43d3437455522a00a30718cdedb5", size = 3373542, upload-time = "2026-01-05T10:40:52.803Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Splits #5 (PR 1 of 4)

This PR is the first of four pieces splitting #5, in response to review feedback that #5 was too large to review in one pass:

1. **Pipeline core (this PR)** — `pipeline.py` + named-stage masker refactor
2. Telemetry observer + per-phase latency
3. Offline eval framework + labeled corpora
4. PII persistence + encryption + triage CLI/skill

The four PRs are **stacked**, so #2's diff will include this PR's content until this lands; same for #3 against #2 and #4 against #3. Reviewing in order is the cleanest path. After this lands the others rebase onto main and shrink to their own contribution.

## What this includes

- New `anon_proxy/pipeline.py`: `AttributedSpan`, `OverlapEvent`, `ResolveResult`, `OverlapPolicy`, and `GreedyLongerWins`. Type definitions plus a behavior-preserving overlap resolver, exposed as a swappable policy.
- `Masker` refactored to delegate overlap resolution to a policy and to expose named pipeline stages (`_detect_ml`, `_detect_user`, `_resolve`, `_replace`). Each stage has a single responsibility and can be tested or swapped in isolation.
- `GreedyLongerWins.resolve()` reproduces the prior `_resolve_overlaps` exactly, so masked output is unchanged.
- Main's `mask` cache and skip-pattern fast paths from #7 / 7e09eac are preserved on top of the new structure.
- New `tests/test_pipeline.py` covering AttributedSpan / OverlapEvent / ResolveResult invariants and the GreedyLongerWins policy (9 tests).

## Test plan

- [x] `uv run pytest tests/test_pipeline.py -v` — 9/9 pass
- [x] Smoke: import `Masker`; mask + unmask round-trip; cache hit; skip-pattern bypass

## Human handoff

(none — pure internal refactor; no infra change, no breaking API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)