### PR TITLE
Add ONNX privacy filter backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,21 @@ uv run python -m anon_proxy.server --backend onnx
 ```
 
 The ONNX backend loads the upstream `openai/privacy-filter` ONNX export through
-the same token-classification pipeline interface as the default torch backend,
-so chunking, masking, and merge behavior remain shared.
+the same `PrivacyFilter` interface as the default torch backend, so chunking,
+masking, and merge behavior remain shared. It is the recommended opt-in backend
+when this parity and benchmark gate passes on the target host:
+
+```bash
+uv run --extra onnx anon-proxy-backend-eval
+```
+
+The gate fails if ONNX misses any entity detected by the torch backend, or if the
+ONNX warm-median latency improvement is less than 30%.
+
+Current validation on the built-in samples: ONNX detected every torch-detected
+entity and measured 38.0% faster warm median (`0.200s` vs `0.323s`, 3 measured
+iterations after 1 warmup). Re-run the gate on deployment hardware before relying
+on that speedup.
 
 ### Config file
 

--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ claude[1]> Sure <PERSON_1>, here's the summary of the note from <EMAIL_1>: ...
 
 - Python ≥ 3.10 (use [uv](https://docs.astral.sh/uv/))
 - CUDA GPU recommended (≥4 GB VRAM); CPU works but is slower
-- Apple Silicon (M1/M2/M3/M4) supported via MPS or MLX backends
+- Apple Silicon (M1/M2/M3/M4) supported via the MPS backend
 - `ANTHROPIC_API_KEY` for `test_mask.py`; the proxy itself forwards client auth — no key needed on the server
 
 ```bash
 uv sync        # install dependencies
-uv sync --extra mlx  # optional: Apple Silicon MLX support
+uv sync --extra onnx  # optional: ONNX Runtime backend
 ```
 
 **Dependencies:** `torch`, `transformers` (local PII model), `starlette` + `uvicorn` (proxy server), `httpx` (upstream client), `anthropic` + `prompt-toolkit` (demo scripts).
@@ -110,12 +110,16 @@ uv run python -m anon_proxy.server [options]
 |---|---|---|
 | `--host` | `127.0.0.1` | Bind address (`0.0.0.0` to expose on LAN) |
 | `--port` | `8080` | Listen port |
-| `--backend` | `auto` | PII detection backend (`auto`, `cpu`, `mps`, `mlx`) |
+| `--backend` | `auto` | PII detection backend (`auto`, `cpu`, `mps`, `onnx`) |
+| `--onnx-provider` | `CPUExecutionProvider` | ONNX Runtime execution provider used with `--backend onnx` |
 | `--extra-upstream` | — | Add custom provider: `name=url[;adapter=anthropic\|openai][;path_prefix=/path]` |
 | `--store <file>` | — | Path to persistent PII mapping store. Loaded at startup; saved after each request with new entries. Enables cross-restart placeholder consistency — see [Persistent store](#persistent-store) below. |
 | `--debug` | off | Log new store entries and masked/unmasked diffs to stderr |
+| `--metrics` | off | Log per-turn latency metrics to stderr |
+| `--capture <file>` | — | Append sensitive local JSONL captures for offline analysis. Capture files contain raw PII; keep them local. |
 | `--config <file>` | — | Unified `config.json` (extra regex patterns, per-label merge-gap overrides, ML labels to skip masking on). See [Config file](#config-file) below. |
-| `--chunk-size <N>` | `1500` | Max chars per model inference pass — lower values reduce peak VRAM |
+| `--chunk-size <N>` | `6000` | Max chars per model inference chunk — lower values reduce peak VRAM |
+| `--batch-size <N>` | `8` | Batch size for model inference over chunks |
 | `--no-system-inject` | off | Disable the placeholder-explainer system prompt that the proxy prepends to outbound requests. Also settable via `system_inject: false` in `config.json`. |
 
 **Add a custom provider:**
@@ -133,6 +137,16 @@ uv run python -m anon_proxy.server \
   --backend mps \
   --debug
 ```
+
+**With ONNX Runtime:**
+```bash
+uv sync --extra onnx
+uv run python -m anon_proxy.server --backend onnx
+```
+
+The ONNX backend loads the upstream `openai/privacy-filter` ONNX export through
+the same token-classification pipeline interface as the default torch backend,
+so chunking, masking, and merge behavior remain shared.
 
 ### Config file
 
@@ -198,6 +212,27 @@ The store is a flat JSON file — human-readable, easy to inspect, backup, or pr
 Writes are atomic (written to a `.tmp` file, then renamed) and offloaded to a thread pool so they never block the event loop. If a write fails (disk full, permissions), the error is logged to stderr and the request completes normally — the mapping survives in memory and will be retried on the next write.
 
 Also settable via `ANON_PROXY_STORE` environment variable.
+
+Inspect or clean a store with `anon-proxy-store` after stopping the proxy:
+
+```bash
+uv run anon-proxy-store --store /data/pii_store.json list --label PERSON
+uv run anon-proxy-store --store /data/pii_store.json show '<PERSON_1>'
+uv run anon-proxy-store --store /data/pii_store.json purge '<PERSON_42>'
+```
+
+Bulk-prune short false-positive fragments with a dry run first:
+
+```bash
+uv run anon-proxy-store --store /data/pii_store.json prune --label PERSON --max-len 3 --dry-run
+uv run anon-proxy-store --store /data/pii_store.json prune --label PERSON --max-len 3
+```
+
+`purge` and non-dry-run `prune` write `/data/pii_store.json.bak` before
+modifying the store. Counters are never decremented, so deleted placeholder
+indexes are not reused in old transcripts. `prune` requires at least one filter
+or an explicit `--all`; this prevents an accidental bare prune from selecting
+the entire store.
 
 ## Docker
 
@@ -290,6 +325,20 @@ With `--debug`, each request prints a compact diff to stderr:
 **What is NOT masked:** the system prompt (tool schemas and static instructions), tool definitions, and extended-thinking blocks (signatures would break). See [`SECURITY.md`](SECURITY.md) for the full threat model and known limitations.
 
 **How it works:** PII spans get stable placeholder tokens (`<PERSON_1>`, `<EMAIL_1>`, `<ADDRESS_1>`, …) stored in an in-memory mapping. The same value always maps to the same token across turns so the model stays coherent. Optionally persist this mapping to disk with `--store` (see [Persistent store](#persistent-store)). Responses are unmasked before reaching your client.
+
+### Capture reports
+
+When `--capture` is enabled, mask telemetry records safe per-entity detector metadata:
+`label`, `score`, `len`, and `source`. It deliberately does not record the matched
+text in detector telemetry. Summarize capture files with:
+
+```bash
+uv run anon-proxy-capture-report /data/capture.jsonl
+uv run anon-proxy-capture-report --json /data/capture.jsonl
+```
+
+The report prints per-label score histograms and source counts without emitting
+request or response text from the capture file.
 
 ---
 

--- a/anon_proxy/adapters/anthropic.py
+++ b/anon_proxy/adapters/anthropic.py
@@ -151,6 +151,7 @@ async def transform_stream(
     masker: Masker,
     *,
     on_substitution: Callable[[str, str], None] | None = None,
+    on_usage: Callable[[dict], None] | None = None,
 ) -> AsyncIterator[bytes]:
     """Unmask masked payloads in an Anthropic SSE stream.
 
@@ -186,6 +187,7 @@ async def transform_stream(
                 masker,
                 blocks,
                 on_substitution,
+                on_usage,
             ):
                 yield _serialize_sse(out_event, out_data)
     if raw.strip():
@@ -226,6 +228,7 @@ def _transform_event(
     masker: Masker,
     blocks: dict[int, dict],
     on_substitution: Callable[[str, str], None] | None,
+    on_usage: Callable[[dict], None] | None,
 ):
     """Transform a single SSE event, unmasking content where needed.
 
@@ -245,6 +248,11 @@ def _transform_event(
     except json.JSONDecodeError:
         yield event_type, data_str
         return
+
+    if event_type == "message_start" and on_usage is not None:
+        usage = (data.get("message") or {}).get("usage")
+        if isinstance(usage, dict):
+            on_usage(usage)
 
     if event_type == "content_block_start":
         # A new content block is starting. Set up state for tracking deltas.

--- a/anon_proxy/adapters/openai.py
+++ b/anon_proxy/adapters/openai.py
@@ -249,6 +249,7 @@ async def transform_stream(
     masker: Masker,
     *,
     on_substitution: Callable[[str, str], None] | None = None,
+    on_usage: Callable[[dict], None] | None = None,
 ) -> AsyncIterator[bytes]:
     """Unmask masked payloads in an OpenAI SSE stream.
 
@@ -294,6 +295,7 @@ async def transform_stream(
                 tool_call_buffers,
                 content_buffer,
                 on_substitution,
+                on_usage,
             ):
                 yield _serialize_sse(out_event, out_data)
 
@@ -346,6 +348,7 @@ def _transform_event(
     tool_call_buffers: dict[int, str],
     content_buffer: list[str],  # Changed to mutable list to allow modification
     on_substitution: Callable[[str, str], None] | None,
+    on_usage: Callable[[dict], None] | None,
 ):
     """Transform a single SSE event.
 
@@ -363,6 +366,10 @@ def _transform_event(
     except json.JSONDecodeError:
         yield event_type, data_str
         return
+
+    usage = data.get("usage")
+    if isinstance(usage, dict) and on_usage is not None:
+        on_usage(usage)
 
     choices = data.get("choices", [])
     if not isinstance(choices, list):

--- a/anon_proxy/backend_eval.py
+++ b/anon_proxy/backend_eval.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import statistics
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+from anon_proxy.mapping import normalize_label
+from anon_proxy.privacy_filter import PIIEntity, PrivacyFilter
+
+
+DEFAULT_EVAL_TEXTS = [
+    "Alice Smith called from 555-867-5309 about bob@example.com.",
+    "Send the contract to 123 Main St., Apt #4 before Jan 1, 2027.",
+    "Dr. Jean-Luc O'Neil met ACME Corp in San Francisco.",
+]
+
+
+@dataclass(frozen=True)
+class EntitySignature:
+    label: str
+    text: str
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class ParityResult:
+    text: str
+    reference: tuple[EntitySignature, ...]
+    candidate: tuple[EntitySignature, ...]
+    missing: tuple[EntitySignature, ...]
+
+    @property
+    def passed(self) -> bool:
+        return not self.missing
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    reference_median_s: float
+    candidate_median_s: float
+
+    @property
+    def speedup(self) -> float:
+        if self.reference_median_s <= 0:
+            return 0.0
+        return 1.0 - (self.candidate_median_s / self.reference_median_s)
+
+
+def signature(entity: PIIEntity) -> EntitySignature:
+    return EntitySignature(
+        label=normalize_label(entity.label),
+        text=entity.text,
+        start=entity.start,
+        end=entity.end,
+    )
+
+
+def missing_reference_entities(
+    reference: Sequence[PIIEntity],
+    candidate: Sequence[PIIEntity],
+) -> tuple[EntitySignature, ...]:
+    candidate_signatures = tuple(signature(entity) for entity in candidate)
+    missing: list[EntitySignature] = []
+    for reference_entity in reference:
+        reference_signature = signature(reference_entity)
+        if not any(
+            _covers(reference_signature, candidate_signature)
+            for candidate_signature in candidate_signatures
+        ):
+            missing.append(reference_signature)
+    return tuple(missing)
+
+
+def _covers(reference: EntitySignature, candidate: EntitySignature) -> bool:
+    return (
+        candidate.label == reference.label
+        and candidate.start <= reference.start
+        and candidate.end >= reference.end
+    )
+
+
+def check_parity(
+    reference_filter: PrivacyFilter,
+    candidate_filter: PrivacyFilter,
+    texts: Sequence[str] = DEFAULT_EVAL_TEXTS,
+) -> list[ParityResult]:
+    results: list[ParityResult] = []
+    for text in texts:
+        reference = reference_filter.detect(text)
+        candidate = candidate_filter.detect(text)
+        results.append(
+            ParityResult(
+                text=text,
+                reference=tuple(signature(entity) for entity in reference),
+                candidate=tuple(signature(entity) for entity in candidate),
+                missing=missing_reference_entities(reference, candidate),
+            )
+        )
+    return results
+
+
+def benchmark_filter(
+    detector: Callable[[str], list[PIIEntity]],
+    texts: Sequence[str] = DEFAULT_EVAL_TEXTS,
+    *,
+    warmups: int = 1,
+    iterations: int = 5,
+) -> float:
+    for _ in range(warmups):
+        for text in texts:
+            detector(text)
+
+    timings: list[float] = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        for text in texts:
+            detector(text)
+        timings.append(time.perf_counter() - start)
+    return statistics.median(timings)
+
+
+def compare_backends(
+    reference_filter: PrivacyFilter,
+    candidate_filter: PrivacyFilter,
+    texts: Sequence[str] = DEFAULT_EVAL_TEXTS,
+    *,
+    warmups: int = 1,
+    iterations: int = 5,
+) -> BenchmarkResult:
+    return BenchmarkResult(
+        reference_median_s=benchmark_filter(
+            reference_filter.detect,
+            texts,
+            warmups=warmups,
+            iterations=iterations,
+        ),
+        candidate_median_s=benchmark_filter(
+            candidate_filter.detect,
+            texts,
+            warmups=warmups,
+            iterations=iterations,
+        ),
+    )

--- a/anon_proxy/backend_eval_cli.py
+++ b/anon_proxy/backend_eval_cli.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from anon_proxy.backend_eval import DEFAULT_EVAL_TEXTS, check_parity, compare_backends
+from anon_proxy.privacy_filter import PrivacyFilter
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare PrivacyFilter backends for entity parity and latency."
+    )
+    parser.add_argument(
+        "--texts",
+        nargs="*",
+        default=DEFAULT_EVAL_TEXTS,
+        help="Texts to evaluate. Defaults to built-in PII samples.",
+    )
+    parser.add_argument(
+        "--warmups",
+        type=int,
+        default=1,
+        help="Warmup iterations before timing.",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=5,
+        help="Measured timing iterations.",
+    )
+    parser.add_argument(
+        "--min-speedup",
+        type=float,
+        default=0.30,
+        help="Required ONNX warm-median speedup versus torch.",
+    )
+    parser.add_argument(
+        "--onnx-provider",
+        default="CPUExecutionProvider",
+        help="ONNX Runtime execution provider.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON.",
+    )
+    args = parser.parse_args()
+
+    torch_filter = PrivacyFilter(backend="torch", device="cpu")
+    onnx_filter = PrivacyFilter(
+        backend="onnx",
+        onnx_provider=args.onnx_provider,
+    )
+
+    parity = check_parity(torch_filter, onnx_filter, args.texts)
+    benchmark = compare_backends(
+        torch_filter,
+        onnx_filter,
+        args.texts,
+        warmups=args.warmups,
+        iterations=args.iterations,
+    )
+    passed = all(result.passed for result in parity) and (
+        benchmark.speedup >= args.min_speedup
+    )
+
+    payload = {
+        "parity_passed": all(result.passed for result in parity),
+        "benchmark_passed": benchmark.speedup >= args.min_speedup,
+        "required_speedup": args.min_speedup,
+        "speedup": benchmark.speedup,
+        "torch_median_s": benchmark.reference_median_s,
+        "onnx_median_s": benchmark.candidate_median_s,
+        "parity": [
+            {
+                "text": result.text,
+                "reference": [entity.__dict__ for entity in result.reference],
+                "candidate": [entity.__dict__ for entity in result.candidate],
+                "missing": [entity.__dict__ for entity in result.missing],
+            }
+            for result in parity
+        ],
+    }
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(
+            f"torch median: {benchmark.reference_median_s:.3f}s; "
+            f"onnx median: {benchmark.candidate_median_s:.3f}s; "
+            f"speedup: {benchmark.speedup:.1%}"
+        )
+        for result in parity:
+            if result.missing:
+                print(f"missing entities for {result.text!r}: {result.missing}")
+
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/anon_proxy/capture_report.py
+++ b/anon_proxy/capture_report.py
@@ -53,7 +53,9 @@ def main(argv: list[str] | None = None) -> int:
         description="Summarize safe detector telemetry from anon-proxy capture JSONL.",
     )
     parser.add_argument("captures", nargs="+", help="Capture JSONL files to read.")
-    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    parser.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of text."
+    )
     args = parser.parse_args(argv)
     try:
         report = build_report([Path(p) for p in args.captures])

--- a/anon_proxy/capture_report.py
+++ b/anon_proxy/capture_report.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+_BINS = tuple(f"{i / 10:.1f}-{(i + 1) / 10:.1f}" for i in range(10))
+
+
+def build_report(paths: list[str | Path]) -> dict[str, Any]:
+    labels: dict[str, dict[str, Any]] = {}
+    files = [str(Path(path)) for path in paths]
+    records = 0
+    entities = 0
+    for path in paths:
+        with Path(path).open(encoding="utf-8") as f:
+            for line_no, line in enumerate(f, start=1):
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as e:
+                    raise ValueError(f"{path}:{line_no}: invalid JSON: {e}") from e
+                records += 1
+                for entity in _iter_entities(record):
+                    label = str(entity["label"])
+                    bucket = labels.setdefault(label, _new_bucket())
+                    score = float(entity["score"])
+                    length = int(entity["len"])
+                    source = str(entity["source"])
+                    bucket["count"] += 1
+                    bucket["_score_total"] += score
+                    bucket["_len_total"] += length
+                    bucket["min_score"] = min(bucket["min_score"], score)
+                    bucket["max_score"] = max(bucket["max_score"], score)
+                    bucket["score_histogram"][_score_bin(score)] += 1
+                    bucket["sources"][source] += 1
+                    entities += 1
+    return {
+        "files": files,
+        "records": records,
+        "entities": entities,
+        "labels": {label: _finalize_bucket(bucket) for label, bucket in labels.items()},
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="anon-proxy-capture-report",
+        description="Summarize safe detector telemetry from anon-proxy capture JSONL.",
+    )
+    parser.add_argument("captures", nargs="+", help="Capture JSONL files to read.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    args = parser.parse_args(argv)
+    try:
+        report = build_report([Path(p) for p in args.captures])
+    except (OSError, ValueError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_text_report(report)
+    return 0
+
+
+def _iter_entities(record: dict[str, Any]):
+    timing = record.get("timing_ms")
+    if not isinstance(timing, dict):
+        return
+    calls = timing.get("detector_calls")
+    if not isinstance(calls, list):
+        return
+    for call in calls:
+        if not isinstance(call, dict) or call.get("op") != "mask":
+            continue
+        entities = call.get("entities")
+        if not isinstance(entities, list):
+            continue
+        for entity in entities:
+            if _valid_entity(entity):
+                yield entity
+
+
+def _valid_entity(entity: Any) -> bool:
+    return (
+        isinstance(entity, dict)
+        and isinstance(entity.get("label"), str)
+        and isinstance(entity.get("source"), str)
+        and isinstance(entity.get("score"), (int, float))
+        and isinstance(entity.get("len"), int)
+    )
+
+
+def _new_bucket() -> dict[str, Any]:
+    return {
+        "count": 0,
+        "_score_total": 0.0,
+        "_len_total": 0,
+        "min_score": 1.0,
+        "max_score": 0.0,
+        "score_histogram": Counter({label: 0 for label in _BINS}),
+        "sources": Counter(),
+    }
+
+
+def _finalize_bucket(bucket: dict[str, Any]) -> dict[str, Any]:
+    count = bucket["count"]
+    return {
+        "count": count,
+        "avg_score": round(bucket["_score_total"] / count, 4) if count else 0.0,
+        "min_score": round(bucket["min_score"], 4) if count else 0.0,
+        "max_score": round(bucket["max_score"], 4) if count else 0.0,
+        "avg_len": round(bucket["_len_total"] / count, 2) if count else 0.0,
+        "score_histogram": dict(bucket["score_histogram"]),
+        "sources": dict(bucket["sources"]),
+    }
+
+
+def _score_bin(score: float) -> str:
+    clamped = min(max(score, 0.0), 1.0)
+    index = min(int(clamped * 10), 9)
+    return _BINS[index]
+
+
+def _print_text_report(report: dict[str, Any]) -> None:
+    print(
+        f"capture files: {len(report['files'])}  "
+        f"records: {report['records']}  entities: {report['entities']}"
+    )
+    for label, data in sorted(report["labels"].items()):
+        sources = ", ".join(f"{k}={v}" for k, v in sorted(data["sources"].items()))
+        print(
+            f"\n{label}: count={data['count']} avg_score={data['avg_score']:.4f} "
+            f"min={data['min_score']:.4f} max={data['max_score']:.4f} "
+            f"avg_len={data['avg_len']:.2f} sources={sources}"
+        )
+        for bucket, count in data["score_histogram"].items():
+            if count:
+                print(f"  {bucket}: {count}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/anon_proxy/mapping.py
+++ b/anon_proxy/mapping.py
@@ -33,7 +33,7 @@ class PIIStore:
         if not value or not value.strip():
             raise ValueError(
                 "PIIStore.get_or_create: value must be non-empty after stripping whitespace"
-        )
+            )
         normalized_label = normalize_label(label)
         key = (normalized_label, _canonical(value))
         with self._lock:

--- a/anon_proxy/mapping.py
+++ b/anon_proxy/mapping.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import threading
 from dataclasses import dataclass
 
 
@@ -18,44 +19,50 @@ class PIIStore:
     maps to the same token for the life of this store. The reverse map preserves
     the first-seen original form so un-masking restores the user's casing.
 
-    Not thread-safe — instances are expected to be used sequentially within a
-    single request or conversation.
+    Thread-safe: a reentrant lock guards the maps and counters so request
+    masking can run in worker threads while response unmasking stays inline.
     """
 
     def __init__(self) -> None:
         self._forward: dict[tuple[str, str], Placeholder] = {}
         self._reverse: dict[str, str] = {}
         self._counters: dict[str, int] = {}
+        self._lock = threading.RLock()
 
     def get_or_create(self, label: str, value: str) -> Placeholder:
         if not value or not value.strip():
             raise ValueError(
                 "PIIStore.get_or_create: value must be non-empty after stripping whitespace"
-            )
+        )
         normalized_label = normalize_label(label)
         key = (normalized_label, _canonical(value))
-        existing = self._forward.get(key)
-        if existing is not None:
-            return existing
-        index = self._counters.get(normalized_label, 0) + 1
-        self._counters[normalized_label] = index
-        token = f"<{normalized_label}_{index}>"
-        ph = Placeholder(label=normalized_label, index=index, token=token)
-        self._forward[key] = ph
-        self._reverse[token] = value
-        return ph
+        with self._lock:
+            existing = self._forward.get(key)
+            if existing is not None:
+                return existing
+            index = self._counters.get(normalized_label, 0) + 1
+            self._counters[normalized_label] = index
+            token = f"<{normalized_label}_{index}>"
+            ph = Placeholder(label=normalized_label, index=index, token=token)
+            self._forward[key] = ph
+            self._reverse[token] = value
+            return ph
 
     def original(self, token: str) -> str | None:
-        return self._reverse.get(token)
+        with self._lock:
+            return self._reverse.get(token)
 
     def tokens(self) -> list[str]:
-        return list(self._reverse.keys())
+        with self._lock:
+            return list(self._reverse.keys())
 
     def items(self) -> list[tuple[str, str]]:
-        return list(self._reverse.items())
+        with self._lock:
+            return list(self._reverse.items())
 
     def __len__(self) -> int:
-        return len(self._reverse)
+        with self._lock:
+            return len(self._reverse)
 
     # ---- serialization --------------------------------------------------
 
@@ -68,10 +75,11 @@ class PIIStore:
 
         The forward map is reconstructed on deserialization.
         """
-        return {
-            "reverse": dict(self._reverse),
-            "counters": dict(self._counters),
-        }
+        with self._lock:
+            return {
+                "reverse": dict(self._reverse),
+                "counters": dict(self._counters),
+            }
 
     @classmethod
     def from_dict(cls, data: dict) -> "PIIStore":
@@ -81,6 +89,8 @@ class PIIStore:
         round-trip preserves all mappings.
         """
         store = cls()
+        # The fresh store is not published yet, so direct population does not
+        # need to acquire its lock.
         store._reverse = dict(data["reverse"])
         store._counters = dict(data["counters"])
         for token, original in store._reverse.items():
@@ -94,10 +104,7 @@ class PIIStore:
 
     def save(self, path: str) -> None:
         """Atomically write the store to *path* as JSON."""
-        tmp = path + ".tmp"
-        with open(tmp, "w") as f:
-            json.dump(self.to_dict(), f, indent=2)
-        os.replace(tmp, path)
+        atomic_write_json(path, self.to_dict())
 
     @classmethod
     def load(cls, path: str) -> "PIIStore":
@@ -108,6 +115,21 @@ class PIIStore:
         except json.JSONDecodeError as e:
             raise ValueError(f"{path}: invalid JSON — {e}") from e
         return cls.from_dict(data)
+
+
+def atomic_write_json(path: str, data: dict) -> None:
+    """Atomically write *data* as JSON, readable by the owner only (0600).
+
+    Store files map placeholders back to raw PII, so they get the same
+    permissions as a credentials file. `os.replace` preserves the tmp file's
+    mode, and `fchmod` covers a leftover tmp from a crashed write.
+    """
+    tmp = path + ".tmp"
+    fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        os.fchmod(fd, 0o600)
+        json.dump(data, f, indent=2)
+    os.replace(tmp, path)
 
 
 _WHITESPACE = re.compile(r"\s+")

--- a/anon_proxy/masker.py
+++ b/anon_proxy/masker.py
@@ -3,6 +3,7 @@ import contextvars
 import hashlib
 import json
 import re
+import threading
 import time
 from collections import OrderedDict
 from typing import Any, Callable, Iterable, Protocol
@@ -22,7 +23,9 @@ def telemetry_scope():
     """Collect per-call masker telemetry into a fresh list for the current task.
 
     Each entry: {"op": "mask"|"unmask"|"unmask_json", "chars": int, "ms": float,
-    "cache_hit": bool (mask only), "skipped": bool (mask, optional)}.
+    "cache_hit": bool (mask only), "skipped": bool (mask, optional),
+    "entities": [{"label": str, "score": float, "len": int, "source": str}, ...]
+    (mask only)}. Entity telemetry deliberately excludes matched text.
     Safe under concurrent asyncio tasks — each task gets its own list via contextvars.
     """
     record: list = []
@@ -47,6 +50,7 @@ _SKIP_MASK_PATTERNS = [
 
 # Matches placeholder tokens emitted by PIIStore (see mapping.py: f"<{LABEL}_{N}>").
 _PLACEHOLDER_RE = re.compile(r"<[A-Z][A-Z0-9_]*_\d+>")
+_CACHE_MISS = object()
 
 
 class Masker:
@@ -88,8 +92,11 @@ class Masker:
             normalize_label(s) for s in (ignore_labels or ())
         )
         self._cache_size = cache_size
-        # LRU cache: content_hash -> (entities, masked_text)
-        self._cache: OrderedDict[str, tuple[list[PIIEntity], str]] = OrderedDict()
+        self._cache_lock = threading.RLock()
+        # LRU cache: content_hash -> (safe entity telemetry, masked_text)
+        self._cache: OrderedDict[str, tuple[list[dict[str, Any]], str]] = (
+            OrderedDict()
+        )
         # LRU cache: block_hash -> already-masked block-shaped object
         self._block_cache: OrderedDict[str, Any] = OrderedDict()
 
@@ -123,8 +130,11 @@ class Masker:
 
         # Check cache
         content_hash = _hash_content(text)
-        if cached := self._cache.get(content_hash):
-            self._cache.move_to_end(content_hash)
+        with self._cache_lock:
+            cached = self._cache.get(content_hash)
+            if cached is not None:
+                self._cache.move_to_end(content_hash)
+        if cached is not None:
             if record is not None:
                 record.append(
                     {
@@ -132,6 +142,7 @@ class Masker:
                         "chars": len(text),
                         "ms": (time.perf_counter() - t0) * 1000,
                         "cache_hit": True,
+                        "entities": list(cached[0]),
                     }
                 )
             return cached[1]
@@ -144,6 +155,7 @@ class Masker:
         for detector in self._extra:
             regex_entities.extend(detector.detect(text))
         regex_entities = _resolve_overlaps(regex_entities)
+        regex_telemetry = _entity_telemetry(regex_entities, source="regex")
         intermediate = self._substitute(text, regex_entities)
 
         # Pass 2: ML model on the regex-masked text. Defensively drop any span
@@ -160,9 +172,14 @@ class Masker:
                 if normalize_label(e.label) not in self._ignore_labels
             ]
         ml_entities = _resolve_overlaps(ml_entities)
+        ml_telemetry = _entity_telemetry(ml_entities, source="ml")
         masked = self._substitute(intermediate, ml_entities)
 
-        self._cache_result(content_hash, regex_entities + ml_entities, masked)
+        # Detection may race for the same uncached text. That is harmless:
+        # PIIStore allocation is idempotent, and both threads write the same
+        # content-hash cache entry.
+        entities = regex_telemetry + ml_telemetry
+        self._cache_result(content_hash, entities, masked)
         if record is not None:
             record.append(
                 {
@@ -170,18 +187,20 @@ class Masker:
                     "chars": len(text),
                     "ms": (time.perf_counter() - t0) * 1000,
                     "cache_hit": False,
+                    "entities": entities,
                 }
             )
         return masked
 
     def _cache_result(
-        self, content_hash: str, entities: list[PIIEntity], masked: str
+        self, content_hash: str, entities: list[dict[str, Any]], masked: str
     ) -> None:
         """Cache a detection result with LRU eviction."""
-        self._cache[content_hash] = (entities, masked)
-        self._cache.move_to_end(content_hash)
-        while len(self._cache) > self._cache_size:
-            self._cache.popitem(last=False)
+        with self._cache_lock:
+            self._cache[content_hash] = (list(entities), masked)
+            self._cache.move_to_end(content_hash)
+            while len(self._cache) > self._cache_size:
+                self._cache.popitem(last=False)
 
     def _substitute(self, text: str, entities: list[PIIEntity]) -> str:
         """Replace entities with placeholder tokens.
@@ -217,9 +236,11 @@ class Masker:
             return walker(obj)
         record = _TELEMETRY.get()
         t0 = time.perf_counter() if record is not None else 0.0
-        if key in self._block_cache:
-            self._block_cache.move_to_end(key)
-            cached = self._block_cache[key]
+        with self._cache_lock:
+            cached = self._block_cache.get(key, _CACHE_MISS)
+            if cached is not _CACHE_MISS:
+                self._block_cache.move_to_end(key)
+        if cached is not _CACHE_MISS:
             if record is not None:
                 record.append(
                     {
@@ -230,10 +251,11 @@ class Masker:
                 )
             return cached
         result = walker(obj)
-        self._block_cache[key] = result
-        self._block_cache.move_to_end(key)
-        while len(self._block_cache) > self._cache_size:
-            self._block_cache.popitem(last=False)
+        with self._cache_lock:
+            self._block_cache[key] = result
+            self._block_cache.move_to_end(key)
+            while len(self._block_cache) > self._cache_size:
+                self._block_cache.popitem(last=False)
         if record is not None:
             record.append(
                 {
@@ -309,6 +331,19 @@ def _drop_placeholder_overlaps(entities: list[PIIEntity], text: str) -> list[PII
         e
         for e in entities
         if not any(e.start < pe and e.end > ps for ps, pe in placeholders)
+    ]
+
+
+def _entity_telemetry(entities: list[PIIEntity], *, source: str) -> list[dict[str, Any]]:
+    """Return safe per-entity telemetry without matched text."""
+    return [
+        {
+            "label": normalize_label(e.label),
+            "score": float(e.score),
+            "len": e.end - e.start,
+            "source": source,
+        }
+        for e in entities
     ]
 
 

--- a/anon_proxy/masker.py
+++ b/anon_proxy/masker.py
@@ -94,9 +94,7 @@ class Masker:
         self._cache_size = cache_size
         self._cache_lock = threading.RLock()
         # LRU cache: content_hash -> (safe entity telemetry, masked_text)
-        self._cache: OrderedDict[str, tuple[list[dict[str, Any]], str]] = (
-            OrderedDict()
-        )
+        self._cache: OrderedDict[str, tuple[list[dict[str, Any]], str]] = OrderedDict()
         # LRU cache: block_hash -> already-masked block-shaped object
         self._block_cache: OrderedDict[str, Any] = OrderedDict()
 
@@ -334,7 +332,9 @@ def _drop_placeholder_overlaps(entities: list[PIIEntity], text: str) -> list[PII
     ]
 
 
-def _entity_telemetry(entities: list[PIIEntity], *, source: str) -> list[dict[str, Any]]:
+def _entity_telemetry(
+    entities: list[PIIEntity], *, source: str
+) -> list[dict[str, Any]]:
     """Return safe per-entity telemetry without matched text."""
     return [
         {

--- a/anon_proxy/privacy_filter.py
+++ b/anon_proxy/privacy_filter.py
@@ -2,7 +2,6 @@ import threading
 from dataclasses import dataclass
 from typing import Literal
 
-import numpy as np
 from transformers import pipeline
 
 
@@ -159,6 +158,35 @@ def _build_pipeline(
 
 def _load_onnx_model(*, provider: str):
     try:
+        return _load_onnx_model_with_optimum(provider=provider)
+    except (ImportError, RuntimeError, ValueError, OSError):
+        return _load_onnx_model_with_runtime(provider=provider)
+
+
+def _load_onnx_model_with_optimum(*, provider: str):
+    try:
+        from optimum.onnxruntime import ORTModelForTokenClassification
+        from transformers import AutoTokenizer
+    except ImportError as e:
+        raise ImportError("optimum.onnxruntime is unavailable") from e
+
+    model = ORTModelForTokenClassification.from_pretrained(
+        PrivacyFilter.MODEL_ID,
+        subfolder="onnx",
+        file_name="model_q4f16.onnx",
+        provider=provider,
+    )
+    tokenizer = AutoTokenizer.from_pretrained(PrivacyFilter.MODEL_ID)
+    return pipeline(
+        task="token-classification",
+        model=model,
+        tokenizer=tokenizer,
+        aggregation_strategy="simple",
+    )
+
+
+def _load_onnx_model_with_runtime(*, provider: str):
+    try:
         import onnxruntime as ort
     except ImportError as e:
         raise RuntimeError(
@@ -238,6 +266,8 @@ class _OnnxTokenClassificationPipeline:
 
 
 def _softmax(logits):
+    import numpy as np
+
     shifted = logits - np.max(logits, axis=-1, keepdims=True)
     exp = np.exp(shifted)
     return exp / np.sum(exp, axis=-1, keepdims=True)

--- a/anon_proxy/privacy_filter.py
+++ b/anon_proxy/privacy_filter.py
@@ -152,7 +152,9 @@ def _build_pipeline(
     if backend == "onnx":
         return _load_onnx_model(provider=onnx_provider)
     allowed = "auto, torch, cpu, mps, onnx"
-    raise ValueError(f"unsupported privacy filter backend {backend!r}; expected {allowed}")
+    raise ValueError(
+        f"unsupported privacy filter backend {backend!r}; expected {allowed}"
+    )
 
 
 def _load_onnx_model(*, provider: str):
@@ -208,9 +210,7 @@ class _OnnxTokenClassificationPipeline:
         )
         offsets = encoded.pop("offset_mapping")[0].tolist()
         ort_inputs = {
-            name: encoded[name]
-            for name in self._input_names
-            if name in encoded
+            name: encoded[name] for name in self._input_names if name in encoded
         }
         logits = self._session.run(None, ort_inputs)[0][0]
         probabilities = _softmax(logits)

--- a/anon_proxy/privacy_filter.py
+++ b/anon_proxy/privacy_filter.py
@@ -1,5 +1,8 @@
+import threading
 from dataclasses import dataclass
+from typing import Literal
 
+import numpy as np
 from transformers import pipeline
 
 
@@ -28,6 +31,12 @@ DEFAULT_MERGE_GAP_ALLOWED: dict[str, str] = {
     "LOCATION": " \t\n,.-",
 }
 
+DEFAULT_CHUNK_SIZE = 6000
+DEFAULT_ONNX_FILE = "onnx/model_q4f16.onnx"
+DEFAULT_ONNX_DATA_FILES = ("onnx/model_q4f16.onnx_data",)
+DEFAULT_ONNX_PROVIDER = "CPUExecutionProvider"
+Backend = Literal["auto", "torch", "cpu", "mps", "onnx"]
+
 
 class PrivacyFilter:
     """Thin wrapper around the openai/privacy-filter token classifier.
@@ -47,11 +56,11 @@ class PrivacyFilter:
     merge across an empty gap.
 
     Long texts are split into overlapping-free chunks of at most `chunk_size`
-    characters (default 1500, ~375 English tokens — safely within BERT's 512
-    token limit). Splits happen at the last whitespace before the boundary so
-    words are never bisected. Entity spans from adjacent chunks are combined
-    before the adjacency-merge pass, so entities that straddle a chunk boundary
-    are still collapsed into a single placeholder.
+    characters (default 6000, roughly 1500 English tokens). Splits happen at
+    the last whitespace before the boundary so words are never bisected.
+    Chunks are submitted to the pipeline as one batch. Entity spans from
+    adjacent chunks are combined before the adjacency-merge pass, so entities
+    that straddle a chunk boundary are still collapsed into a single placeholder.
     """
 
     MODEL_ID = "openai/privacy-filter"
@@ -62,14 +71,18 @@ class PrivacyFilter:
         aggregation_strategy: str = "simple",
         merge_adjacent: bool = True,
         merge_gap_allowed: dict[str, str] | None = None,
-        chunk_size: int = 1500,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+        batch_size: int = 8,
         device: int | str | None = None,
+        backend: Backend = "auto",
+        onnx_provider: str = DEFAULT_ONNX_PROVIDER,
     ) -> None:
-        self._pipe = pipeline(
-            task="token-classification",
-            model=self.MODEL_ID,
+        self._pipe = _build_pipeline(
+            model_id=self.MODEL_ID,
             aggregation_strategy=aggregation_strategy,
+            backend=backend,
             device=device,
+            onnx_provider=onnx_provider,
         )
         self._merge_adjacent = merge_adjacent
         merged_policy = {**DEFAULT_MERGE_GAP_ALLOWED, **(merge_gap_allowed or {})}
@@ -77,14 +90,19 @@ class PrivacyFilter:
             label: frozenset(chars) for label, chars in merged_policy.items()
         }
         self._chunk_size = chunk_size
+        self._batch_size = batch_size
+        self._infer_lock = threading.Lock()
 
     def detect(self, text: str) -> list[PIIEntity]:
         if not text.strip():
             return []
         chunks = _split_chunks(text, self._chunk_size)
+        texts = [chunk for _, chunk in chunks]
+        with self._infer_lock:
+            all_results = self._pipe(texts, batch_size=self._batch_size)
         entities: list[PIIEntity] = []
-        for offset, chunk in chunks:
-            for r in self._pipe(chunk):
+        for (offset, chunk), results in zip(chunks, all_results):
+            for r in results:
                 e = _to_entity(r, chunk)
                 if e is None:
                     continue
@@ -103,7 +121,163 @@ class PrivacyFilter:
 
     def detect_raw(self, text: str) -> list[dict]:
         """Return the pipeline's untouched per-span dicts for debugging."""
-        return list(self._pipe(text))
+        with self._infer_lock:
+            return list(self._pipe(text))
+
+
+def _build_pipeline(
+    *,
+    model_id: str,
+    aggregation_strategy: str,
+    backend: Backend,
+    device: int | str | None,
+    onnx_provider: str,
+):
+    if backend in ("auto", "torch"):
+        return pipeline(
+            task="token-classification",
+            model=model_id,
+            aggregation_strategy=aggregation_strategy,
+            device=device,
+        )
+    if backend in ("cpu", "mps"):
+        if device is None:
+            device = backend
+        return pipeline(
+            task="token-classification",
+            model=model_id,
+            aggregation_strategy=aggregation_strategy,
+            device=device,
+        )
+    if backend == "onnx":
+        return _load_onnx_model(provider=onnx_provider)
+    allowed = "auto, torch, cpu, mps, onnx"
+    raise ValueError(f"unsupported privacy filter backend {backend!r}; expected {allowed}")
+
+
+def _load_onnx_model(*, provider: str):
+    try:
+        import onnxruntime as ort
+    except ImportError as e:
+        raise RuntimeError(
+            "ONNX backend requires the optional onnx dependencies. "
+            "Install them with `uv sync --extra onnx`."
+        ) from e
+
+    try:
+        from huggingface_hub import hf_hub_download
+        from transformers import AutoConfig, AutoTokenizer
+    except ImportError as e:
+        raise RuntimeError(
+            "transformers and huggingface_hub are required to load the ONNX model"
+        ) from e
+
+    model_path = hf_hub_download(PrivacyFilter.MODEL_ID, filename=DEFAULT_ONNX_FILE)
+    for filename in DEFAULT_ONNX_DATA_FILES:
+        hf_hub_download(PrivacyFilter.MODEL_ID, filename=filename)
+    tokenizer = AutoTokenizer.from_pretrained(PrivacyFilter.MODEL_ID)
+    config = AutoConfig.from_pretrained(PrivacyFilter.MODEL_ID, trust_remote_code=True)
+    session = ort.InferenceSession(model_path, providers=[provider])
+    return _OnnxTokenClassificationPipeline(session, tokenizer, config.id2label)
+
+
+class _OnnxTokenClassificationPipeline:
+    """Pipeline-shaped ONNX Runtime token classifier.
+
+    It returns the subset of HuggingFace token-classification pipeline fields
+    consumed by `_to_entity`: `entity_group`, `start`, `end`, `word`, `score`.
+    """
+
+    def __init__(self, session, tokenizer, id2label: dict[int | str, str]) -> None:
+        self._session = session
+        self._tokenizer = tokenizer
+        self._id2label = {int(k): v for k, v in id2label.items()}
+        self._input_names = {i.name for i in session.get_inputs()}
+
+    def __call__(self, inputs, **_kwargs):
+        if isinstance(inputs, str):
+            return self._detect_one(inputs)
+        return [self._detect_one(text) for text in inputs]
+
+    def _detect_one(self, text: str) -> list[dict]:
+        encoded = self._tokenizer(
+            text,
+            return_offsets_mapping=True,
+            return_tensors="np",
+            truncation=True,
+        )
+        offsets = encoded.pop("offset_mapping")[0].tolist()
+        ort_inputs = {
+            name: encoded[name]
+            for name in self._input_names
+            if name in encoded
+        }
+        logits = self._session.run(None, ort_inputs)[0][0]
+        probabilities = _softmax(logits)
+        label_ids = probabilities.argmax(axis=-1)
+        scores = probabilities.max(axis=-1)
+
+        tokens = []
+        for label_id, score, (start, end) in zip(label_ids, scores, offsets):
+            if start == end:
+                continue
+            label = self._id2label.get(int(label_id), "O")
+            if label == "O":
+                continue
+            prefix, entity = _split_tag(label)
+            tokens.append(
+                {
+                    "prefix": prefix,
+                    "entity": entity,
+                    "start": int(start),
+                    "end": int(end),
+                    "score": float(score),
+                }
+            )
+        return _aggregate_tokens(tokens, text)
+
+
+def _softmax(logits):
+    shifted = logits - np.max(logits, axis=-1, keepdims=True)
+    exp = np.exp(shifted)
+    return exp / np.sum(exp, axis=-1, keepdims=True)
+
+
+def _split_tag(label: str) -> tuple[str, str]:
+    if len(label) > 2 and label[1] == "-" and label[0] in "BIES":
+        return label[0], label[2:]
+    return "B", label
+
+
+def _aggregate_tokens(tokens: list[dict], text: str) -> list[dict]:
+    spans: list[dict] = []
+    current: dict | None = None
+    for token in tokens:
+        starts_new = (
+            current is None
+            or token["prefix"] in ("B", "S")
+            or token["entity"] != current["entity_group"]
+        )
+        if starts_new:
+            if current is not None:
+                spans.append(current)
+            current = {
+                "entity_group": token["entity"],
+                "start": token["start"],
+                "end": token["end"],
+                "score": token["score"],
+            }
+        else:
+            current["end"] = token["end"]
+            current["score"] = min(current["score"], token["score"])
+        if token["prefix"] == "S" and current is not None:
+            spans.append(current)
+            current = None
+    if current is not None:
+        spans.append(current)
+    for span in spans:
+        span["word"] = text[span["start"] : span["end"]]
+    return spans
 
 
 def _split_chunks(text: str, max_chars: int) -> list[tuple[int, str]]:

--- a/anon_proxy/server.py
+++ b/anon_proxy/server.py
@@ -18,7 +18,6 @@ import asyncio
 import contextlib
 import json
 import os
-import random
 import sys
 import time
 from collections.abc import AsyncIterator
@@ -190,14 +189,46 @@ def _log_stream_substitutions(substitutions: dict[str, str]) -> None:
     sys.stderr.flush()
 
 
-def _log_metrics(provider: str, e2e: float, upstream: float) -> None:
+def _extract_usage(resp_json: dict) -> dict | None:
+    """Normalize Anthropic/OpenAI usage blocks for the metrics line."""
+    usage = resp_json.get("usage")
+    if not isinstance(usage, dict):
+        return None
+    if "input_tokens" in usage:
+        return {
+            "input": usage.get("input_tokens", 0),
+            "cache_read": usage.get("cache_read_input_tokens", 0),
+            "cache_creation": usage.get("cache_creation_input_tokens", 0),
+        }
+    if "prompt_tokens" in usage:
+        details = usage.get("prompt_tokens_details") or {}
+        return {
+            "input": usage.get("prompt_tokens", 0),
+            "cache_read": details.get("cached_tokens", 0),
+            "cache_creation": 0,
+        }
+    return None
+
+
+def _log_metrics(
+    provider: str,
+    e2e: float,
+    upstream: float,
+    usage: dict | None = None,
+) -> None:
     """Print per-turn latency breakdown to stderr."""
     proxy = max(e2e - upstream, 0.0)
     pct = (proxy / e2e * 100.0) if e2e > 0 else 0.0
+    token_part = ""
+    if usage is not None:
+        token_part = (
+            f"  tokens: in={usage['input']} cache_read={usage['cache_read']} "
+            f"cache_create={usage['cache_creation']}"
+        )
     print(
         f"{_MAGENTA}[metrics {provider}]{_RESET} "
         f"e2e={e2e * 1000:.1f}ms  upstream={upstream * 1000:.1f}ms  "
-        f"proxy={proxy * 1000:.1f}ms ({pct:.1f}%)",
+        f"proxy={proxy * 1000:.1f}ms ({pct:.1f}%){token_part}",
         file=sys.stderr,
     )
     sys.stderr.flush()
@@ -226,17 +257,6 @@ async def _timed_aiter(
         yield chunk
 
 
-def _parse_retry_after(headers) -> float | None:
-    """Parse Retry-After header value in seconds, or None if absent/unparseable."""
-    val = headers.get("retry-after") or headers.get("Retry-After")
-    if val is None:
-        return None
-    try:
-        return float(val)
-    except ValueError:
-        return None
-
-
 async def _upstream_request(
     client: httpx.AsyncClient,
     method: str,
@@ -246,41 +266,16 @@ async def _upstream_request(
     headers: dict[str, str] | None = None,
     params: dict | None = None,
     stream: bool = False,
-    max_retries: int = 3,
 ) -> httpx.Response:
-    """Send an upstream request, retrying on 429.
+    """Build and send one upstream request.
 
-    If the upstream returns 429 and retries remain: reads the Retry-After header
-    and waits that many seconds; falls back to exponential backoff with jitter
-    (base 1s, doubled per retry) when the header is absent. Each retry attempt
-    prints a line to stderr.
-
-    Gives up after *max_retries* consecutive 429s and returns the final 429
-    response to the caller.
+    Clients already retry 429s with their own backoff. Retrying inside the proxy
+    multiplies upstream pressure and hides the rate-limit signal from callers.
     """
-    for attempt in range(max_retries + 1):
-        req = client.build_request(
-            method, url, content=content, headers=headers, params=params
-        )
-        resp = await client.send(req, stream=stream)
-        if resp.status_code != 429 or attempt == max_retries:
-            return resp
-
-        retry_after = _parse_retry_after(resp.headers)
-        if retry_after is None:
-            retry_after = (2**attempt) * (0.5 + random.random() * 0.5)
-
-        print(
-            f"  upstream 429 (retry {attempt + 1}/{max_retries}), "
-            f"waiting {retry_after:.1f}s",
-            file=sys.stderr,
-        )
-        if stream:
-            await resp.aread()
-        await resp.aclose()
-        await asyncio.sleep(retry_after)
-
-    raise RuntimeError("_upstream_request: exhausted retries")  # unreachable
+    req = client.build_request(
+        method, url, content=content, headers=headers, params=params
+    )
+    return await client.send(req, stream=stream)
 
 
 _SKIP_REQUEST_HEADERS = {
@@ -499,6 +494,7 @@ async def _handle_proxy(
         async def body_iter():
             # For streaming, track substitutions for debug logging
             substitutions: dict[str, str] = {}
+            usage_acc: list[dict] = []
 
             def track_substitution(upstream: str, client: str):
                 """Track placeholder → unmasked substitutions."""
@@ -523,6 +519,7 @@ async def _handle_proxy(
                         ),
                         masker,
                         on_substitution=track_substitution if debug else None,
+                        on_usage=usage_acc.append,
                     ):
                         if downstream_byte_acc is not None:
                             downstream_byte_acc.append(out)
@@ -534,10 +531,17 @@ async def _handle_proxy(
                 if debug:
                     _log_stream_substitutions(substitutions)
                 if metrics:
+                    usage = None
+                    if usage_acc:
+                        merged = {}
+                        for usage_chunk in usage_acc:
+                            merged.update(usage_chunk)
+                        usage = _extract_usage({"usage": merged})
                     _log_metrics(
                         upstream_config.name,
                         time.perf_counter() - t_start,
                         upstream_acc[0],
+                        usage=usage,
                     )
                 if capture is not None:
                     e2e_s = time.perf_counter() - t_start
@@ -609,7 +613,10 @@ async def _handle_proxy(
                 _log_response(resp_json, unmasked)
             if metrics:
                 _log_metrics(
-                    upstream_config.name, time.perf_counter() - t_start, upstream_acc[0]
+                    upstream_config.name,
+                    time.perf_counter() - t_start,
+                    upstream_acc[0],
+                    usage=_extract_usage(resp_json),
                 )
             if capture is not None:
                 e2e_s = time.perf_counter() - t_start

--- a/anon_proxy/server.py
+++ b/anon_proxy/server.py
@@ -35,9 +35,9 @@ from anon_proxy.adapters import anthropic as anthropic_adapter
 from anon_proxy.adapters import openai as openai_adapter
 from anon_proxy.capture import Capturer
 from anon_proxy.config import Config, load_config
-from anon_proxy.mapping import PIIStore
+from anon_proxy.mapping import PIIStore, atomic_write_json
 from anon_proxy.masker import Masker, telemetry_scope
-from anon_proxy.privacy_filter import PrivacyFilter
+from anon_proxy.privacy_filter import DEFAULT_CHUNK_SIZE, PrivacyFilter
 from anon_proxy.regex_detector import RegexDetector
 from anon_proxy.system_prompt import PLACEHOLDER_SYSTEM_PROMPT
 from anon_proxy.upstream import BUILT_IN_UPSTREAMS, UpstreamConfig, get_upstream_config
@@ -447,11 +447,11 @@ async def _handle_proxy(
     if capture is not None:
         with telemetry_scope() as calls:
             t_mask = time.perf_counter()
-            masked = adapter.mask_request(body, masker)
+            masked = await asyncio.to_thread(adapter.mask_request, body, masker)
             mask_request_ms = (time.perf_counter() - t_mask) * 1000
             mask_calls = list(calls)
     else:
-        masked = adapter.mask_request(body, masker)
+        masked = await asyncio.to_thread(adapter.mask_request, body, masker)
     if debug:
         new_entries = masker.store.items()[store_before:]
         _log_request(upstream_config.name, api_path, body, masked, new_entries)
@@ -657,18 +657,6 @@ async def _handle_proxy(
     )
 
 
-def _write_store_json(path: str, data: dict) -> None:
-    """Atomically write serialized store data to *path*.
-
-    Runs in a thread pool — *data* is a snapshot captured on the event loop,
-    so concurrent store mutations during the write are harmless.
-    """
-    tmp = path + ".tmp"
-    with open(tmp, "w") as f:
-        json.dump(data, f, indent=2)
-    os.replace(tmp, path)
-
-
 async def _maybe_save_store(app_state, store_before: int) -> None:
     """Write the PII store to disk if it was modified this request.
 
@@ -681,7 +669,7 @@ async def _maybe_save_store(app_state, store_before: int) -> None:
     if len(masker.store) > store_before:
         data = masker.store.to_dict()
         try:
-            await asyncio.to_thread(_write_store_json, store_path, data)
+            await asyncio.to_thread(atomic_write_json, store_path, data)
         except OSError as e:
             print(f"error: failed to save PII store: {e}", file=sys.stderr)
 
@@ -782,6 +770,34 @@ def _parse_extra_upstream(spec: str) -> tuple[str, UpstreamConfig]:
     )
 
 
+def _make_privacy_filter(args, cfg: Config) -> PrivacyFilter | None:
+    if args.backend == "mlx":
+        raise ValueError("unsupported backend 'mlx'; use 'mps' or 'onnx'")
+    if (
+        cfg.merge_gap
+        or args.chunk_size != DEFAULT_CHUNK_SIZE
+        or args.batch_size != 8
+        or args.backend != "auto"
+    ):
+        if args.backend == "onnx":
+            return PrivacyFilter(
+                merge_gap_allowed=cfg.merge_gap or None,
+                chunk_size=args.chunk_size,
+                batch_size=args.batch_size,
+                backend="onnx",
+                onnx_provider=args.onnx_provider,
+            )
+        device = None if args.backend == "auto" else args.backend
+        return PrivacyFilter(
+            merge_gap_allowed=cfg.merge_gap or None,
+            chunk_size=args.chunk_size,
+            batch_size=args.batch_size,
+            backend="torch",
+            device=device,
+        )
+    return None
+
+
 def main() -> None:
     import argparse
     import uvicorn
@@ -835,21 +851,29 @@ def main() -> None:
     parser.add_argument(
         "--chunk-size",
         type=int,
-        default=int(os.environ.get("ANON_PROXY_CHUNK_SIZE", "1500")),
+        default=int(os.environ.get("ANON_PROXY_CHUNK_SIZE", str(DEFAULT_CHUNK_SIZE))),
         metavar="N",
-        help="Max characters per chunk fed to the model (default: 1500). "
+        help=f"Max characters per chunk fed to the model (default: {DEFAULT_CHUNK_SIZE}). "
         "Lower values reduce peak GPU memory at the cost of more forward passes.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=int(os.environ.get("ANON_PROXY_BATCH_SIZE", "8")),
+        metavar="N",
+        help="Batch size for model inference over chunks (default: 8).",
     )
     parser.add_argument(
         "--backend",
         default=os.environ.get("ANON_PROXY_BACKEND", "auto"),
-        choices=["auto", "cpu", "mps", "mlx"],
+        choices=["auto", "cpu", "mps", "onnx"],
         help="PII detection backend (default: auto-detect best available).",
     )
     parser.add_argument(
-        "--mlx-weights-cache",
-        default=os.environ.get("ANON_PROXY_MLX_WEIGHTS_CACHE"),
-        help="Path to cached MLX-converted weights. Generated on first use if not found.",
+        "--onnx-provider",
+        default=os.environ.get("ANON_PROXY_ONNX_PROVIDER", "CPUExecutionProvider"),
+        help="ONNX Runtime execution provider for --backend onnx "
+        "(default: CPUExecutionProvider).",
     )
     parser.add_argument(
         "--no-system-inject",
@@ -900,14 +924,11 @@ def main() -> None:
             print(f"error: {e}", file=sys.stderr)
             sys.exit(2)
 
-    pf: PrivacyFilter | None = None
-    if cfg.merge_gap or args.chunk_size != 1500 or args.backend != "auto":
-        device = None if args.backend == "auto" else args.backend
-        pf = PrivacyFilter(
-            merge_gap_allowed=cfg.merge_gap or None,
-            chunk_size=args.chunk_size,
-            device=device,
-        )
+    try:
+        pf = _make_privacy_filter(args, cfg)
+    except (RuntimeError, ValueError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(2)
 
     # Load persistent PII store if requested.
     store_path: str | None = args.store

--- a/anon_proxy/store_cli.py
+++ b/anon_proxy/store_cli.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from copy import deepcopy
+
+from anon_proxy.mapping import _parse_token, atomic_write_json, normalize_label
+
+
+def filter_entries(
+    data: dict,
+    label: str | None,
+    min_len: int | None,
+    max_len: int | None,
+) -> list[tuple[str, str, str]]:
+    rows: list[tuple[str, str, str]] = []
+    normalized_label = normalize_label(label) if label is not None else None
+    for token, value in data["reverse"].items():
+        parsed = _parse_token(token)
+        if parsed is None:
+            continue
+        token_label, _index = parsed
+        if normalized_label is not None and token_label != normalized_label:
+            continue
+        value_len = len(value)
+        if min_len is not None and value_len < min_len:
+            continue
+        if max_len is not None and value_len > max_len:
+            continue
+        rows.append((token, token_label, value))
+    return sorted(rows, key=lambda row: row[0])
+
+
+def purge_tokens(data: dict, tokens: list[str]) -> tuple[dict, list[str], list[str]]:
+    new_data = deepcopy(data)
+    reverse = new_data["reverse"]
+    removed: list[str] = []
+    missing: list[str] = []
+    for token in tokens:
+        if token in reverse:
+            del reverse[token]
+            removed.append(token)
+        else:
+            missing.append(token)
+    return new_data, removed, missing
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    store_path = args.store or args.global_store or os.environ.get("ANON_PROXY_STORE")
+    if not store_path:
+        parser.error("--store or ANON_PROXY_STORE is required")
+
+    print(
+        "warning: stop anon-proxy before editing the store; "
+        "if it is running, restart it to pick up changes.",
+        file=sys.stderr,
+    )
+    data = _load_store(store_path)
+
+    if args.command == "list":
+        rows = filter_entries(data, args.label, args.min_len, args.max_len)
+        for token, label, value in rows:
+            print(f"{token}\t{label}\t{_truncate(value)}\t{len(value)}")
+        return 0
+
+    if args.command == "show":
+        value = data["reverse"].get(args.token)
+        if value is None:
+            print(f"not found: {args.token}", file=sys.stderr)
+            return 1
+        print(value)
+        return 0
+
+    if args.command == "purge":
+        new_data, removed, missing = purge_tokens(data, args.tokens)
+        for token in missing:
+            print(f"not found: {token}", file=sys.stderr)
+        if removed:
+            _backup_then_write(store_path, new_data)
+            for token in removed:
+                print(f"removed {token}")
+        return 1 if missing else 0
+
+    if args.command == "prune":
+        _validate_prune_filters(parser, args)
+        rows = filter_entries(data, args.label, args.min_len, args.max_len)
+        tokens = [token for token, _label, _value in rows]
+        new_data, removed, _missing = purge_tokens(data, tokens)
+        for token in removed:
+            prefix = "would remove" if args.dry_run else "removed"
+            print(f"{prefix} {token}")
+        if removed and not args.dry_run:
+            _backup_then_write(store_path, new_data)
+        return 0
+
+    parser.error("missing command")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="anon-proxy-store",
+        description="Inspect and clean an anon-proxy PII mapping store.",
+    )
+    parser.add_argument("--store", dest="global_store")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = subparsers.add_parser("list")
+    _add_store_arg(list_parser)
+    _add_filter_args(list_parser)
+
+    show_parser = subparsers.add_parser("show")
+    _add_store_arg(show_parser)
+    show_parser.add_argument("token")
+
+    purge_parser = subparsers.add_parser("purge")
+    _add_store_arg(purge_parser)
+    purge_parser.add_argument("tokens", nargs="+")
+
+    prune_parser = subparsers.add_parser("prune")
+    _add_store_arg(prune_parser)
+    _add_filter_args(prune_parser)
+    prune_parser.add_argument("--all", action="store_true")
+    prune_parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def _add_store_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--store")
+
+
+def _add_filter_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--label")
+    parser.add_argument("--min-len", type=int)
+    parser.add_argument("--max-len", type=int)
+
+
+def _validate_prune_filters(parser: argparse.ArgumentParser, args) -> None:
+    has_filter = (
+        args.label is not None or args.min_len is not None or args.max_len is not None
+    )
+    if not has_filter and not args.all:
+        parser.error("prune requires at least one filter or --all")
+
+
+def _load_store(path: str) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+def _backup_then_write(path: str, new_data: dict) -> None:
+    shutil.copyfile(path, path + ".bak")
+    atomic_write_json(path, new_data)
+
+
+def _truncate(value: str, limit: int = 80) -> str:
+    if len(value) <= limit:
+        return value
+    return value[: limit - 3] + "..."
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ classifiers = [
 dependencies = [
     "anthropic>=0.96.0",
     "httpx>=0.28.1",
-    "numpy>=2.2.0",
     "openai>=2.35.1",
     "prompt-toolkit>=3.0.52",
     "starlette>=1.0.0",
@@ -61,6 +60,7 @@ Issues = "https://github.com/KevinXuxuxu/anon_proxy/issues"
 
 [project.scripts]
 anon-proxy = "anon_proxy.server:main"
+anon-proxy-backend-eval = "anon_proxy.backend_eval_cli:main"
 anon-proxy-capture-report = "anon_proxy.capture_report:main"
 anon-proxy-store = "anon_proxy.store_cli:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,19 @@ classifiers = [
 dependencies = [
     "anthropic>=0.96.0",
     "httpx>=0.28.1",
+    "numpy>=2.2.0",
     "openai>=2.35.1",
     "prompt-toolkit>=3.0.52",
     "starlette>=1.0.0",
     "torch>=2.11.0",
     "transformers>=5.6.0",
     "uvicorn[standard]>=0.45.0",
+]
+
+[project.optional-dependencies]
+onnx = [
+    "onnxruntime>=1.20,<1.24; python_version < '3.11'",
+    "onnxruntime>=1.20; python_version >= '3.11'",
 ]
 
 [project.urls]
@@ -54,6 +61,8 @@ Issues = "https://github.com/KevinXuxuxu/anon_proxy/issues"
 
 [project.scripts]
 anon-proxy = "anon_proxy.server:main"
+anon-proxy-capture-report = "anon_proxy.capture_report:main"
+anon-proxy-store = "anon_proxy.store_cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/test_filter.py
+++ b/test_filter.py
@@ -14,7 +14,7 @@ import sys
 from collections.abc import Sequence
 
 from anon_proxy.config import load_config
-from anon_proxy.privacy_filter import PIIEntity, PrivacyFilter
+from anon_proxy.privacy_filter import DEFAULT_CHUNK_SIZE, PIIEntity, PrivacyFilter
 
 YELLOW = "\033[93m"
 DIM = "\033[2m"
@@ -113,9 +113,9 @@ def main() -> int:
     parser.add_argument(
         "--chunk-size",
         type=int,
-        default=1500,
+        default=DEFAULT_CHUNK_SIZE,
         metavar="N",
-        help="Max characters per chunk fed to the model (default: 1500). "
+        help=f"Max characters per chunk fed to the model (default: {DEFAULT_CHUNK_SIZE}). "
         "Lower values reduce peak GPU memory at the cost of more passes.",
     )
     parser.add_argument(

--- a/test_mask.py
+++ b/test_mask.py
@@ -37,6 +37,7 @@ from prompt_toolkit import ANSI, PromptSession
 from prompt_toolkit.key_binding import KeyBindings
 
 from anon_proxy import Config, Masker, PrivacyFilter, RegexDetector, load_config
+from anon_proxy.privacy_filter import DEFAULT_CHUNK_SIZE
 from anon_proxy.system_prompt import PLACEHOLDER_SYSTEM_PROMPT
 
 
@@ -135,9 +136,9 @@ def main() -> int:
     parser.add_argument(
         "--chunk-size",
         type=int,
-        default=1500,
+        default=DEFAULT_CHUNK_SIZE,
         metavar="N",
-        help="Max characters per chunk fed to the model (default: 1500).",
+        help=f"Max characters per chunk fed to the model (default: {DEFAULT_CHUNK_SIZE}).",
     )
     args = parser.parse_args()
 
@@ -178,7 +179,7 @@ def main() -> int:
                 print(f"{RED}error:{RESET} {e}", file=sys.stderr)
                 return 2
         pf: PrivacyFilter | None = None
-        if cfg.merge_gap or args.chunk_size != 1500:
+        if cfg.merge_gap or args.chunk_size != DEFAULT_CHUNK_SIZE:
             pf = PrivacyFilter(
                 merge_gap_allowed=cfg.merge_gap or None,
                 chunk_size=args.chunk_size,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ class FakePipeline:
     def set(self, text: str, spans: list[dict]) -> None:
         self._responses[text] = spans
 
-    def __call__(self, inputs):
+    def __call__(self, inputs, **_kwargs):
         if isinstance(inputs, str):
             self.calls.append(inputs)
             return list(self._responses.get(inputs, []))

--- a/tests/test_adapter_streaming.py
+++ b/tests/test_adapter_streaming.py
@@ -782,6 +782,66 @@ class TestAnthropicDecodeFailure:
         assert b"event: content_block_delta" in out
 
 
+@pytest.mark.asyncio
+class TestStreamingUsage:
+    async def test_anthropic_stream_reports_usage(self, make_filter, store):
+        m = _make_masker_with_tokens(make_filter, store)
+        chunks = [
+            _sse_event(
+                "message_start",
+                {
+                    "type": "message_start",
+                    "message": {
+                        "usage": {
+                            "input_tokens": 12,
+                            "cache_read_input_tokens": 300,
+                            "cache_creation_input_tokens": 0,
+                        }
+                    },
+                },
+            ),
+            _sse_event("message_stop", {"type": "message_stop"}),
+        ]
+        seen: list[dict] = []
+
+        async for _ in anth.transform_stream(_aiter(chunks), m, on_usage=seen.append):
+            pass
+
+        assert seen == [
+            {
+                "input_tokens": 12,
+                "cache_read_input_tokens": 300,
+                "cache_creation_input_tokens": 0,
+            }
+        ]
+
+    async def test_openai_stream_reports_usage(self, make_filter, store):
+        m = _make_masker_with_tokens(make_filter, store)
+        chunks = [
+            _oai_event(
+                {
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": 12,
+                        "prompt_tokens_details": {"cached_tokens": 300},
+                    },
+                }
+            ),
+            _oai_event("[DONE]"),
+        ]
+        seen: list[dict] = []
+
+        async for _ in oai.transform_stream(_aiter(chunks), m, on_usage=seen.append):
+            pass
+
+        assert seen == [
+            {
+                "prompt_tokens": 12,
+                "prompt_tokens_details": {"cached_tokens": 300},
+            }
+        ]
+
+
 class TestIsCompleteJson:
     """Pin the _is_complete_json helper that gates tool_call argument
     flushing in the OpenAI adapter. Falsy on invalid JSON, truthy on valid."""

--- a/tests/test_backend_eval.py
+++ b/tests/test_backend_eval.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+
+from anon_proxy.backend_eval import (
+    BenchmarkResult,
+    check_parity,
+    missing_reference_entities,
+)
+from anon_proxy.privacy_filter import PIIEntity
+
+
+class FakeFilter:
+    def __init__(self, responses):
+        self._responses = responses
+
+    def detect(self, text: str):
+        return list(self._responses.get(text, []))
+
+
+def entity(label: str, text: str, start: int, end: int) -> PIIEntity:
+    return PIIEntity(label=label, text=text, start=start, end=end, score=1.0)
+
+
+def test_missing_reference_entities_normalizes_labels():
+    reference = [entity("private_person", "Alice", 0, 5)]
+    candidate = [entity("PERSON", "Alice", 0, 5)]
+
+    assert missing_reference_entities(reference, candidate) == ()
+
+
+def test_missing_reference_entities_reports_any_torch_miss():
+    reference = [
+        entity("private_person", "Alice", 0, 5),
+        entity("private_email", "a@example.com", 10, 23),
+    ]
+    candidate = [entity("private_person", "Alice", 0, 5)]
+
+    missing = missing_reference_entities(reference, candidate)
+
+    assert len(missing) == 1
+    assert missing[0].label == "EMAIL"
+    assert missing[0].text == "a@example.com"
+
+
+def test_covering_candidate_span_is_not_a_miss():
+    reference = [
+        entity("PERSON", "Alice", 0, 5),
+        entity("PERSON", "Smith", 6, 11),
+    ]
+    candidate = [entity("PERSON", "Alice Smith", 0, 11)]
+
+    assert missing_reference_entities(reference, candidate) == ()
+
+
+def test_check_parity_passes_when_candidate_has_reference_entities():
+    text = "Alice and Bob"
+    reference = FakeFilter({text: [entity("PERSON", "Alice", 0, 5)]})
+    candidate = FakeFilter(
+        {
+            text: [
+                entity("PERSON", "Alice", 0, 5),
+                entity("PERSON", "Bob", 10, 13),
+            ]
+        }
+    )
+
+    [result] = check_parity(reference, candidate, [text])
+
+    assert result.passed is True
+
+
+def test_check_parity_fails_when_candidate_misses_reference_entity():
+    text = "Alice"
+    reference = FakeFilter({text: [entity("PERSON", "Alice", 0, 5)]})
+    candidate = FakeFilter({text: []})
+
+    [result] = check_parity(reference, candidate, [text])
+
+    assert result.passed is False
+    assert result.missing[0].text == "Alice"
+
+
+@pytest.mark.parametrize(
+    ("reference", "candidate", "expected"),
+    [
+        (10.0, 7.0, 0.3),
+        (10.0, 10.0, 0.0),
+        (10.0, 12.0, -0.2),
+    ],
+)
+def test_benchmark_speedup(reference, candidate, expected):
+    result = BenchmarkResult(reference_median_s=reference, candidate_median_s=candidate)
+
+    assert result.speedup == pytest.approx(expected)

--- a/tests/test_capture_report.py
+++ b/tests/test_capture_report.py
@@ -1,0 +1,101 @@
+import json
+
+from anon_proxy.capture_report import build_report, main
+
+
+def _write_jsonl(path, records):
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+
+def test_build_report_aggregates_safe_entity_histograms(tmp_path):
+    path = tmp_path / "capture.jsonl"
+    _write_jsonl(
+        path,
+        [
+            {
+                "request": {"pre_mask": {"messages": [{"content": "Alice"}]}},
+                "timing_ms": {
+                    "detector_calls": [
+                        {
+                            "op": "mask",
+                            "entities": [
+                                {
+                                    "label": "PERSON",
+                                    "score": 0.94,
+                                    "len": 5,
+                                    "source": "ml",
+                                },
+                                {
+                                    "label": "EMAIL",
+                                    "score": 1.0,
+                                    "len": 15,
+                                    "source": "regex",
+                                },
+                            ],
+                        }
+                    ]
+                },
+            },
+            {
+                "timing_ms": {
+                    "detector_calls": [
+                        {
+                            "op": "mask",
+                            "entities": [
+                                {
+                                    "label": "PERSON",
+                                    "score": 0.81,
+                                    "len": 3,
+                                    "source": "ml",
+                                }
+                            ],
+                        }
+                    ]
+                },
+            },
+        ],
+    )
+
+    report = build_report([path])
+
+    assert report["files"] == [str(path)]
+    assert report["labels"]["PERSON"]["count"] == 2
+    assert report["labels"]["PERSON"]["score_histogram"]["0.8-0.9"] == 1
+    assert report["labels"]["PERSON"]["score_histogram"]["0.9-1.0"] == 1
+    assert report["labels"]["PERSON"]["sources"] == {"ml": 2}
+    assert report["labels"]["EMAIL"]["sources"] == {"regex": 1}
+    assert "Alice" not in json.dumps(report)
+
+
+def test_cli_prints_histograms_without_raw_capture_text(tmp_path, capsys):
+    path = tmp_path / "capture.jsonl"
+    _write_jsonl(
+        path,
+        [
+            {
+                "request": {"pre_mask": {"messages": [{"content": "Alice"}]}},
+                "timing_ms": {
+                    "detector_calls": [
+                        {
+                            "op": "mask",
+                            "entities": [
+                                {
+                                    "label": "PERSON",
+                                    "score": 0.94,
+                                    "len": 5,
+                                    "source": "ml",
+                                }
+                            ],
+                        }
+                    ]
+                },
+            }
+        ],
+    )
+
+    assert main([str(path)]) == 0
+
+    out = capsys.readouterr().out
+    assert "PERSON" in out
+    assert "0.9-1.0" in out
+    assert "Alice" not in out

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -18,6 +18,8 @@ Specs covered (agreed in Phase 2):
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 
 from anon_proxy.mapping import PIIStore, Placeholder, normalize_label
@@ -87,6 +89,28 @@ class TestGetOrCreateBasics:
         b = store.get_or_create("PERSON", "Bob")
         assert (a.index, b.index) == (1, 2)
         assert (a.token, b.token) == ("<PERSON_1>", "<PERSON_2>")
+
+    def test_get_or_create_is_thread_safe(self):
+        store = PIIStore()
+        values = [f"person-{i % 50}" for i in range(1000)]
+
+        with ThreadPoolExecutor(max_workers=16) as ex:
+            tokens = list(
+                ex.map(lambda v: store.get_or_create("PERSON", v).token, values)
+            )
+
+        by_value: dict[str, set[str]] = {}
+        for value, token in zip(values, tokens):
+            by_value.setdefault(value, set()).add(token)
+
+        assert all(len(ts) == 1 for ts in by_value.values())
+        assert len(store) == 50
+        indexes = sorted(
+            int(token.rstrip(">").rsplit("_", 1)[1])
+            for tokens_for_value in by_value.values()
+            for token in tokens_for_value
+        )
+        assert indexes == list(range(1, 51))
 
 
 class TestRepeatedReuse:

--- a/tests/test_masker.py
+++ b/tests/test_masker.py
@@ -12,9 +12,14 @@ Sub-phases will accumulate here:
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 import re
 
-from anon_proxy.masker import _drop_placeholder_overlaps, _resolve_overlaps
+from anon_proxy.masker import (
+    _drop_placeholder_overlaps,
+    _resolve_overlaps,
+    telemetry_scope,
+)
 from anon_proxy.privacy_filter import PIIEntity
 from anon_proxy.regex_detector import RegexDetector
 
@@ -191,7 +196,7 @@ class TestMaskNoOpPath:
     ):
         m = make_masker()
         m.mask("hello world")
-        assert fake_pipeline.calls == ["hello world"]
+        assert fake_pipeline.calls == [["hello world"]]
 
 
 class TestRegexOnlyPath:
@@ -212,7 +217,7 @@ class TestRegexOnlyPath:
         m = make_masker(extra_detectors=[detector])
         text = "Call 555-1212 today"
         m.mask(text)
-        assert fake_pipeline.calls == ["Call <PHONE_1> today"]
+        assert fake_pipeline.calls == [["Call <PHONE_1> today"]]
 
 
 class TestMlOnlyPath:
@@ -252,6 +257,42 @@ class TestRegexAndMlCombined:
         assert len(store) == 1
         assert store.original("<PERSON_1>") == "Alice"
 
+    def test_mask_telemetry_records_safe_entity_metadata(
+        self, make_masker, fake_pipeline
+    ):
+        detector = RegexDetector({"PHONE": r"\d{3}-\d{4}"})
+        m = make_masker(extra_detectors=[detector])
+        text = "Call 555-1212 about Bob"
+        intermediate = "Call <PHONE_1> about Bob"
+        fake_pipeline.set(intermediate, [span("PERSON", 21, 24, score=0.72)])
+
+        with telemetry_scope() as calls:
+            assert m.mask(text) == "Call <PHONE_1> about <PERSON_1>"
+
+        mask_call = next(call for call in calls if call["op"] == "mask")
+        assert mask_call["entities"] == [
+            {"label": "PHONE", "score": 1.0, "len": 8, "source": "regex"},
+            {"label": "PERSON", "score": 0.72, "len": 3, "source": "ml"},
+        ]
+        assert "555-1212" not in repr(mask_call)
+        assert "Bob" not in repr(mask_call)
+
+    def test_cache_hit_replays_safe_entity_metadata(self, make_masker, fake_pipeline):
+        m = make_masker()
+        fake_pipeline.set("Hello Bob", [span("PERSON", 6, 9, score=0.9)])
+
+        with telemetry_scope():
+            assert m.mask("Hello Bob") == "Hello <PERSON_1>"
+        with telemetry_scope() as calls:
+            assert m.mask("Hello Bob") == "Hello <PERSON_1>"
+
+        mask_call = next(call for call in calls if call["op"] == "mask")
+        assert mask_call["cache_hit"] is True
+        assert mask_call["entities"] == [
+            {"label": "PERSON", "score": 0.9, "len": 3, "source": "ml"}
+        ]
+        assert "Bob" not in repr(mask_call)
+
 
 class TestEmptyExtraDetectorsIsTransparent:
     def test_intermediate_equals_original_when_no_regex_hits(
@@ -261,7 +302,7 @@ class TestEmptyExtraDetectorsIsTransparent:
         text = "no digits here"
         m.mask(text)
         # Regex has no matches → intermediate == original; ML sees original.
-        assert fake_pipeline.calls == ["no digits here"]
+        assert fake_pipeline.calls == [["no digits here"]]
 
 
 class TestExtraDetectorsSeeOriginal:
@@ -447,7 +488,7 @@ class TestSkipPatternsCustom:
         # pipeline IS called (proving the skip didn't fire).
         fake_pipeline.set(text, [])
         m.mask(text)
-        assert fake_pipeline.calls == [text]
+        assert fake_pipeline.calls == [[text]]
 
     def test_custom_pattern_triggers_skip(self, make_masker, fake_pipeline):
         m = make_masker(skip_patterns=[re.compile(r"^IGNORE:")])
@@ -463,7 +504,7 @@ class TestSkipPatternsCustom:
         text = "<system-reminder>x</system-reminder>"
         fake_pipeline.set(text, [])
         m.mask(text)
-        assert fake_pipeline.calls == [text]
+        assert fake_pipeline.calls == [[text]]
 
 
 class TestSkipPatternsNotCached:
@@ -855,7 +896,7 @@ class TestMaskCacheHit:
         b = m.mask(text)
         assert a == b
         # Pipeline only called on the first mask; second is a cache hit.
-        assert fake_pipeline.calls == [text]
+        assert fake_pipeline.calls == [[text]]
 
     def test_different_text_invokes_pipeline_each_time(
         self, make_masker, fake_pipeline
@@ -865,7 +906,20 @@ class TestMaskCacheHit:
         fake_pipeline.set("two", [])
         m.mask("one")
         m.mask("two")
-        assert fake_pipeline.calls == ["one", "two"]
+        assert fake_pipeline.calls == [["one"], ["two"]]
+
+    def test_concurrent_mask_same_text_yields_one_placeholder(
+        self, make_masker, fake_pipeline
+    ):
+        m = make_masker()
+        text = "call Alice now"
+        fake_pipeline.set(text, [span("private_person", 5, 10, word="Alice")])
+
+        with ThreadPoolExecutor(max_workers=8) as ex:
+            results = list(ex.map(lambda _: m.mask(text), range(64)))
+
+        assert len(set(results)) == 1
+        assert results[0] == "call <PERSON_1> now"
 
 
 class TestMaskCacheLruEviction:
@@ -877,7 +931,7 @@ class TestMaskCacheLruEviction:
         # 'a' was evicted when 'c' was inserted; re-masking 'a' calls pipeline.
         m.mask("a")
         # Counts: a, b, c, then a again → 4
-        assert fake_pipeline.calls == ["a", "b", "c", "a"]
+        assert fake_pipeline.calls == [["a"], ["b"], ["c"], ["a"]]
 
 
 class TestPerMaskerContract:
@@ -896,7 +950,7 @@ class TestPerMaskerContract:
         m1.mask(text)
         m2.mask(text)
         # Each Masker called the pipeline independently — caches do not leak.
-        assert fake_pipeline.calls == [text, text]
+        assert fake_pipeline.calls == [[text], [text]]
 
     def test_docstring_documents_per_masker_lifetime(self):
         # Pin via the docstring so a future refactor doesn't silently relax it.

--- a/tests/test_privacy_filter.py
+++ b/tests/test_privacy_filter.py
@@ -21,6 +21,7 @@ from anon_proxy import privacy_filter
 from anon_proxy.privacy_filter import (
     DEFAULT_MERGE_GAP_ALLOWED,
     PrivacyFilter,
+    _aggregate_tokens,
     _gap_mergeable,
     _split_chunks,
     _tighten,
@@ -113,6 +114,51 @@ class TestGapMergeable:
         assert _gap_mergeable("LABEL", "-", allowed) is True
         assert _gap_mergeable("LABEL", " - ", allowed) is True
         assert _gap_mergeable("LABEL", " x ", allowed) is False  # 'x' not allowed
+
+
+class TestOnnxTokenAggregation:
+    def test_bioes_tokens_collapse_to_pipeline_shaped_spans(self):
+        text = "Alice Smith met Bob"
+        spans = _aggregate_tokens(
+            [
+                {"prefix": "B", "entity": "PERSON", "start": 0, "end": 5, "score": 0.9},
+                {"prefix": "E", "entity": "PERSON", "start": 6, "end": 11, "score": 0.8},
+                {"prefix": "S", "entity": "PERSON", "start": 16, "end": 19, "score": 0.7},
+            ],
+            text,
+        )
+
+        assert spans == [
+            {
+                "entity_group": "PERSON",
+                "start": 0,
+                "end": 11,
+                "score": 0.8,
+                "word": "Alice Smith",
+            },
+            {
+                "entity_group": "PERSON",
+                "start": 16,
+                "end": 19,
+                "score": 0.7,
+                "word": "Bob",
+            },
+        ]
+
+    def test_label_change_starts_new_span_without_special_case(self):
+        text = "Alice in Paris"
+        spans = _aggregate_tokens(
+            [
+                {"prefix": "B", "entity": "PERSON", "start": 0, "end": 5, "score": 0.9},
+                {"prefix": "B", "entity": "LOCATION", "start": 9, "end": 14, "score": 0.8},
+            ],
+            text,
+        )
+
+        assert [(s["entity_group"], s["word"]) for s in spans] == [
+            ("PERSON", "Alice"),
+            ("LOCATION", "Paris"),
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -257,13 +303,31 @@ class TestDetectChunking:
             (12, 15, "foo"),
         ]
 
-    def test_pipeline_called_once_per_chunk(self, make_filter, fake_pipeline):
+    def test_multichunk_text_is_one_batched_pipeline_call(
+        self, make_filter, fake_pipeline
+    ):
         text = "hello world foo"
         f = make_filter(chunk_size=10)
         f.detect(text)
-        # Two chunks → two pipeline calls (each with a str arg).
-        assert len(fake_pipeline.calls) == 2
-        assert all(isinstance(c, str) for c in fake_pipeline.calls)
+        assert len(fake_pipeline.calls) == 1
+        assert isinstance(fake_pipeline.calls[0], list)
+        assert "".join(fake_pipeline.calls[0]) == text
+
+    def test_batched_multichunk_offsets_shift_by_chunk_start(
+        self, make_filter, fake_pipeline
+    ):
+        text = "aaaa bbbb cccc dddd"
+        f = make_filter(chunk_size=10)
+        chunks = _split_chunks(text, 10)
+        assert len(chunks) > 1
+        second_offset, second_chunk = chunks[1]
+        fake_pipeline.set(second_chunk, [span("PERSON", 0, 4, score=0.9)])
+
+        [entity] = f.detect(text)
+
+        assert entity.text == second_chunk[:4]
+        assert entity.start == second_offset
+        assert entity.end == second_offset + 4
 
     def test_cross_chunk_adjacency_merge(self, make_filter, fake_pipeline):
         # chunk_size=7, text="Alice Smith":
@@ -419,6 +483,59 @@ class TestConstructor:
         monkeypatch.setattr(privacy_filter, "pipeline", _stub)
         PrivacyFilter(device="cuda:0")
         assert captured["device"] == "cuda:0"
+
+    def test_torch_backend_builds_transformers_pipeline(
+        self, monkeypatch, fake_pipeline
+    ):
+        captured: dict = {}
+
+        def _stub(**kwargs):
+            captured.update(kwargs)
+            return fake_pipeline
+
+        monkeypatch.setattr(privacy_filter, "pipeline", _stub)
+        PrivacyFilter(backend="torch", device="mps")
+        assert captured["model"] == PrivacyFilter.MODEL_ID
+        assert captured["device"] == "mps"
+
+    def test_onnx_backend_uses_upstream_quantized_graph(
+        self, monkeypatch, fake_pipeline
+    ):
+        captured: dict = {}
+
+        def _load_onnx_model(*, provider):
+            captured["provider"] = provider
+            return fake_pipeline
+
+        def _stub(**kwargs):
+            raise AssertionError("ONNX backend must not use transformers.pipeline")
+
+        monkeypatch.setattr(privacy_filter, "_load_onnx_model", _load_onnx_model)
+        monkeypatch.setattr(privacy_filter, "pipeline", _stub)
+
+        f = PrivacyFilter(backend="onnx")
+
+        assert captured["provider"] == "CPUExecutionProvider"
+        assert f._pipe is fake_pipeline
+
+    def test_onnx_backend_accepts_provider_override(self, monkeypatch, fake_pipeline):
+        captured: dict = {}
+
+        def _load_onnx_model(*, provider):
+            captured["provider"] = provider
+            return fake_pipeline
+
+        monkeypatch.setattr(privacy_filter, "_load_onnx_model", _load_onnx_model)
+
+        PrivacyFilter(backend="onnx", onnx_provider="CoreMLExecutionProvider")
+
+        assert captured["provider"] == "CoreMLExecutionProvider"
+
+    def test_invalid_backend_fails_fast(self, monkeypatch, fake_pipeline):
+        monkeypatch.setattr(privacy_filter, "pipeline", lambda **_kw: fake_pipeline)
+
+        with pytest.raises(ValueError, match="backend"):
+            PrivacyFilter(backend="mlx")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_privacy_filter.py
+++ b/tests/test_privacy_filter.py
@@ -122,8 +122,20 @@ class TestOnnxTokenAggregation:
         spans = _aggregate_tokens(
             [
                 {"prefix": "B", "entity": "PERSON", "start": 0, "end": 5, "score": 0.9},
-                {"prefix": "E", "entity": "PERSON", "start": 6, "end": 11, "score": 0.8},
-                {"prefix": "S", "entity": "PERSON", "start": 16, "end": 19, "score": 0.7},
+                {
+                    "prefix": "E",
+                    "entity": "PERSON",
+                    "start": 6,
+                    "end": 11,
+                    "score": 0.8,
+                },
+                {
+                    "prefix": "S",
+                    "entity": "PERSON",
+                    "start": 16,
+                    "end": 19,
+                    "score": 0.7,
+                },
             ],
             text,
         )
@@ -150,7 +162,13 @@ class TestOnnxTokenAggregation:
         spans = _aggregate_tokens(
             [
                 {"prefix": "B", "entity": "PERSON", "start": 0, "end": 5, "score": 0.9},
-                {"prefix": "B", "entity": "LOCATION", "start": 9, "end": 14, "score": 0.8},
+                {
+                    "prefix": "B",
+                    "entity": "LOCATION",
+                    "start": 9,
+                    "end": 14,
+                    "score": 0.8,
+                },
             ],
             text,
         )

--- a/tests/test_privacy_filter.py
+++ b/tests/test_privacy_filter.py
@@ -536,6 +536,46 @@ class TestConstructor:
         assert captured["provider"] == "CPUExecutionProvider"
         assert f._pipe is fake_pipeline
 
+    def test_onnx_loader_prefers_optimum(self, monkeypatch, fake_pipeline):
+        calls: list[str] = []
+
+        def _optimum(*, provider):
+            calls.append(f"optimum:{provider}")
+            return fake_pipeline
+
+        def _runtime(*, provider):
+            calls.append(f"runtime:{provider}")
+            return fake_pipeline
+
+        monkeypatch.setattr(privacy_filter, "_load_onnx_model_with_optimum", _optimum)
+        monkeypatch.setattr(privacy_filter, "_load_onnx_model_with_runtime", _runtime)
+
+        assert (
+            privacy_filter._load_onnx_model(provider="CPUExecutionProvider")
+            is fake_pipeline
+        )
+        assert calls == ["optimum:CPUExecutionProvider"]
+
+    def test_onnx_loader_falls_back_to_runtime(self, monkeypatch, fake_pipeline):
+        calls: list[str] = []
+
+        def _optimum(*, provider):
+            calls.append(f"optimum:{provider}")
+            raise ImportError("missing optimum")
+
+        def _runtime(*, provider):
+            calls.append(f"runtime:{provider}")
+            return fake_pipeline
+
+        monkeypatch.setattr(privacy_filter, "_load_onnx_model_with_optimum", _optimum)
+        monkeypatch.setattr(privacy_filter, "_load_onnx_model_with_runtime", _runtime)
+
+        assert (
+            privacy_filter._load_onnx_model(provider="CPUExecutionProvider")
+            is fake_pipeline
+        )
+        assert calls == ["optimum:CPUExecutionProvider", "runtime:CPUExecutionProvider"]
+
     def test_onnx_backend_accepts_provider_override(self, monkeypatch, fake_pipeline):
         captured: dict = {}
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,56 +1,65 @@
 """Tests for server-level persistence wiring.
 
 Covered:
-- ``_write_store_json`` — raw file-writing helper (sync, runs in thread pool).
 - ``_maybe_save_store`` — the async gate that decides whether to write and
   offloads I/O to a thread.
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
 import os
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
-from anon_proxy.mapping import PIIStore
+from anon_proxy import server
+from anon_proxy.adapters import anthropic as anthropic_adapter
+from anon_proxy.capture import Capturer
+from anon_proxy.mapping import PIIStore, atomic_write_json
+from anon_proxy.masker import Masker
+from anon_proxy.regex_detector import RegexDetector
 from anon_proxy.server import (
+    DEFAULT_CHUNK_SIZE,
     _extract_usage,
+    _make_privacy_filter,
+    build_app,
     _maybe_save_store,
     _should_mask_request,
     _upstream_request,
-    _write_store_json,
 )
 
 
 # ---------------------------------------------------------------------------
-# _write_store_json (the sync I/O helper)
+# atomic_write_json (the shared sync I/O helper)
 # ---------------------------------------------------------------------------
 
 
-class TestWriteStoreJson:
+class TestAtomicWriteJson:
     def test_writes_valid_store_file(self, tmp_path):
         path = tmp_path / "store.json"
         data = {"reverse": {"<PERSON_1>": "Alice"}, "counters": {"PERSON": 2}}
-        _write_store_json(str(path), data)
+        atomic_write_json(str(path), data)
         assert path.exists()
         loaded = PIIStore.load(str(path))
         assert loaded.original("<PERSON_1>") == "Alice"
 
     def test_tmp_file_cleaned_up(self, tmp_path):
         path = tmp_path / "store.json"
-        _write_store_json(str(path), {"reverse": {}, "counters": {}})
+        atomic_write_json(str(path), {"reverse": {}, "counters": {}})
         assert not (tmp_path / "store.json.tmp").exists()
 
     def test_overwrites_existing_file(self, tmp_path):
         path = tmp_path / "store.json"
-        _write_store_json(
+        atomic_write_json(
             str(path), {"reverse": {"<P_1>": "first"}, "counters": {"P": 2}}
         )
         assert PIIStore.load(str(path)).original("<P_1>") == "first"
-        _write_store_json(
+        atomic_write_json(
             str(path), {"reverse": {"<P_1>": "second"}, "counters": {"P": 2}}
         )
         assert PIIStore.load(str(path)).original("<P_1>") == "second"
@@ -58,7 +67,7 @@ class TestWriteStoreJson:
     def test_non_existent_directory_raises(self, tmp_path):
         path = tmp_path / "missing" / "store.json"
         with pytest.raises(OSError):
-            _write_store_json(str(path), {"reverse": {}, "counters": {}})
+            atomic_write_json(str(path), {"reverse": {}, "counters": {}})
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +146,74 @@ class TestMaybeSaveStore:
             store_before=0,
         )
         # Should not raise
+
+
+# ===========================================================================
+# PrivacyFilter CLI wiring
+# ===========================================================================
+
+
+class TestMakePrivacyFilter:
+    @pytest.fixture(autouse=True)
+    def fake_privacy_filter(self, monkeypatch):
+        class FakePrivacyFilter:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+        monkeypatch.setattr(server, "PrivacyFilter", FakePrivacyFilter)
+
+    def test_default_options_defer_to_masker_default_filter(self):
+        args = _state(
+            backend="auto",
+            chunk_size=DEFAULT_CHUNK_SIZE,
+            batch_size=8,
+            onnx_provider="CPUExecutionProvider",
+        )
+        cfg = _state(merge_gap={})
+
+        assert _make_privacy_filter(args, cfg) is None
+
+    def test_onnx_backend_constructs_onnx_filter(self):
+        args = _state(
+            backend="onnx",
+            chunk_size=DEFAULT_CHUNK_SIZE,
+            batch_size=8,
+            onnx_provider="CoreMLExecutionProvider",
+        )
+        cfg = _state(merge_gap={})
+
+        pf = _make_privacy_filter(args, cfg)
+
+        assert pf is not None
+        assert pf.backend == "onnx"
+        assert pf.onnx_provider == "CoreMLExecutionProvider"
+
+    def test_mps_backend_maps_to_torch_device(self):
+        args = _state(
+            backend="mps",
+            chunk_size=DEFAULT_CHUNK_SIZE,
+            batch_size=8,
+            onnx_provider="CPUExecutionProvider",
+        )
+        cfg = _state(merge_gap={})
+
+        pf = _make_privacy_filter(args, cfg)
+
+        assert pf is not None
+        assert pf.backend == "torch"
+        assert pf.device == "mps"
+
+    def test_mlx_backend_is_rejected(self):
+        args = _state(
+            backend="mlx",
+            chunk_size=DEFAULT_CHUNK_SIZE,
+            batch_size=8,
+            onnx_provider="CPUExecutionProvider",
+        )
+        cfg = _state(merge_gap={})
+
+        with pytest.raises(ValueError, match="unsupported backend"):
+            _make_privacy_filter(args, cfg)
 
 
 # ===========================================================================
@@ -265,6 +342,110 @@ class TestUpstreamRequest:
             headers={"Authorization": "Bearer xyz"},
             params={"page": "1"},
         )
+
+
+class TestProxyMaskingConcurrency:
+    @pytest.mark.anyio
+    async def test_event_loop_not_blocked_during_mask(self, monkeypatch):
+        def slow_mask_request(body, masker):
+            time.sleep(0.2)
+            return body
+
+        async def fake_upstream_request(*_args, **_kwargs):
+            response = MagicMock(spec=httpx.Response)
+            response.status_code = 200
+            response.headers = {"content-type": "application/json"}
+            response.json.return_value = {"content": []}
+            return response
+
+        monkeypatch.setattr(anthropic_adapter, "mask_request", slow_mask_request)
+        monkeypatch.setattr(
+            "anon_proxy.server._upstream_request", fake_upstream_request
+        )
+        app = build_app(
+            masker=SimpleNamespace(store=PIIStore(), unmask=lambda text: text),
+            system_inject=False,
+        )
+
+        async def post_messages(client):
+            return await client.post(
+                "/anthropic/v1/messages",
+                json={
+                    "model": "claude-test",
+                    "messages": [{"role": "user", "content": "hello Alice"}],
+                },
+            )
+
+        async with app.router.lifespan_context(app):
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://testserver"
+            ) as client:
+                t0 = time.perf_counter()
+                r1, r2 = await asyncio.gather(
+                    post_messages(client),
+                    post_messages(client),
+                )
+                elapsed = time.perf_counter() - t0
+
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        assert elapsed < 0.35, (
+            f"requests serialized on the event loop: {elapsed:.2f}s"
+        )
+
+
+class TestCaptureDetectorTelemetry:
+    @pytest.mark.anyio
+    async def test_capture_file_contains_safe_per_entity_detector_metadata(
+        self, monkeypatch, tmp_path, make_filter
+    ):
+        async def fake_upstream_request(*_args, **_kwargs):
+            return httpx.Response(
+                200,
+                json={"content": [{"type": "text", "text": "ok"}]},
+                headers={"content-type": "application/json"},
+            )
+
+        monkeypatch.setattr(
+            "anon_proxy.server._upstream_request", fake_upstream_request
+        )
+        capture_path = tmp_path / "capture.jsonl"
+        capturer = Capturer(str(capture_path))
+        masker = Masker(
+            filter=make_filter(),
+            store=PIIStore(),
+            extra_detectors=[RegexDetector({"PHONE": r"\d{3}-\d{4}"})],
+            skip_patterns=[],
+        )
+        app = build_app(masker=masker, capture=capturer, system_inject=False)
+
+        async with app.router.lifespan_context(app):
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://testserver"
+            ) as client:
+                response = await client.post(
+                    "/anthropic/v1/messages",
+                    json={
+                        "model": "claude-test",
+                        "messages": [
+                            {"role": "user", "content": "Call 555-1212 today"}
+                        ],
+                    },
+                )
+
+        assert response.status_code == 200
+        record = json.loads(capture_path.read_text().splitlines()[0])
+        mask_call = next(
+            call
+            for call in record["timing_ms"]["detector_calls"]
+            if call["op"] == "mask"
+        )
+        assert mask_call["entities"] == [
+            {"label": "PHONE", "score": 1.0, "len": 8, "source": "regex"}
+        ]
+        assert "555-1212" not in json.dumps(mask_call)
 
 
 class TestExtractUsage:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -17,8 +17,8 @@ import pytest
 
 from anon_proxy.mapping import PIIStore
 from anon_proxy.server import (
+    _extract_usage,
     _maybe_save_store,
-    _parse_retry_after,
     _should_mask_request,
     _upstream_request,
     _write_store_json,
@@ -140,39 +140,6 @@ class TestMaybeSaveStore:
 
 
 # ===========================================================================
-# _parse_retry_after
-# ===========================================================================
-
-
-class TestParseRetryAfter:
-    """Pure function: parses Retry-After header into seconds."""
-
-    def test_retry_after_seconds(self):
-        headers = {"retry-after": "5"}
-        assert _parse_retry_after(headers) == 5.0
-
-    def test_retry_after_float(self):
-        headers = {"retry-after": "2.5"}
-        assert _parse_retry_after(headers) == 2.5
-
-    def test_no_retry_after_header(self):
-        assert _parse_retry_after({}) is None
-
-    def test_retry_after_invalid_returns_none(self):
-        headers = {"retry-after": "foobar"}
-        assert _parse_retry_after(headers) is None
-
-    def test_retry_after_case_insensitive(self):
-        headers = {"Retry-After": "3"}
-        assert _parse_retry_after(headers) == 3.0
-
-    def test_retry_after_both_forms(self):
-        """When both variants are present, lowercase wins (dict order)."""
-        headers = {"retry-after": "1", "Retry-After": "10"}
-        assert _parse_retry_after(headers) == 1.0
-
-
-# ===========================================================================
 # _should_mask_request
 # ===========================================================================
 
@@ -254,7 +221,7 @@ def mock_client():
 
 
 class TestUpstreamRequest:
-    """Async function: wraps httpx.AsyncClient.send with 429 retry."""
+    """Async function: wraps one httpx.AsyncClient.send."""
 
     @patch("anon_proxy.server.asyncio.sleep", AsyncMock())
     async def test_successful_request(self, mock_client):
@@ -265,80 +232,19 @@ class TestUpstreamRequest:
         client.build_request.assert_called_once()
         client.send.assert_awaited_once()
 
-    @patch("anon_proxy.server.asyncio.sleep", AsyncMock())
-    async def test_single_429_then_success(self, mock_client):
-        client, ok = mock_client
+    async def test_429_passes_through_with_retry_after(self, mock_client):
+        client, _ok = mock_client
         err = _mock_response(429)
-        client.send.side_effect = [err, ok]
-
-        resp = await _upstream_request(client, "POST", "https://example.com/api")
-        assert resp is ok
-        assert resp.status_code == 200
-        # Two attempts: 429, then 200
-        assert client.send.await_count == 2
-        err.aclose.assert_awaited_once()
-
-    @patch("anon_proxy.server.asyncio.sleep", AsyncMock())
-    async def test_exhausts_retries_returns_last_429(self, mock_client):
-        client, ok = mock_client
-        errs = [_mock_response(429) for _ in range(4)]
-        client.send.side_effect = list(errs)
+        err.headers = {"retry-after": "7"}
+        client.send.return_value = err
 
         resp = await _upstream_request(client, "POST", "https://example.com/api")
         assert resp.status_code == 429
-        assert client.send.await_count == 4  # initial + 3 retries
-        # The first 3 responses are drained and closed during retry;
-        # the 4th is returned to the caller (caller owns cleanup).
-        for e in errs[:-1]:
-            e.aclose.assert_awaited_once()
-        errs[-1].aclose.assert_not_awaited()
-
-    async def test_respects_retry_after_header(self, mock_client):
-        client, ok = mock_client
-        err = _mock_response(429, {"retry-after": "2"})
-        client.send.side_effect = [err, ok]
-
-        with patch("anon_proxy.server.asyncio.sleep", AsyncMock()) as mock_sleep:
-            resp = await _upstream_request(client, "POST", "https://example.com/api")
-        assert resp.status_code == 200
-        mock_sleep.assert_awaited_once_with(2.0)
-
-    async def test_exponential_backoff_fallback(self, mock_client):
-        """When Retry-After is absent, use exponential backoff with jitter."""
-        client, ok = mock_client
-        err = _mock_response(429)  # no retry-after
-        client.send.side_effect = [err, ok]
-
-        with (
-            patch("anon_proxy.server.random.random", return_value=0.5),
-            patch("anon_proxy.server.asyncio.sleep", AsyncMock()) as mock_sleep,
-        ):
-            resp = await _upstream_request(client, "POST", "https://example.com/api")
-        assert resp.status_code == 200
-        # attempt 0: 2^0 * (0.5 + 0.5 * 0.5) = 1.0 * 0.75 = 0.75
-        mock_sleep.assert_awaited_once_with(0.75)
-
-    @patch("anon_proxy.server.asyncio.sleep", AsyncMock())
-    async def test_streaming_drains_before_retry(self, mock_client):
-        """Streaming 429 responses must be .aread() before .aclose()."""
-        client, ok = mock_client
-        err = _mock_response(429)
-        client.send.side_effect = [err, ok]
-
-        await _upstream_request(client, "POST", "https://example.com/api", stream=True)
-        err.aread.assert_awaited_once()
-        err.aclose.assert_awaited_once()
-
-    @patch("anon_proxy.server.asyncio.sleep", AsyncMock())
-    async def test_non_streaming_skips_aread(self, mock_client):
-        """Non-streaming 429 responses don't need .aread()."""
-        client, ok = mock_client
-        err = _mock_response(429)
-        client.send.side_effect = [err, ok]
-
-        await _upstream_request(client, "POST", "https://example.com/api", stream=False)
+        assert resp.headers["retry-after"] == "7"
+        client.build_request.assert_called_once()
+        client.send.assert_awaited_once()
         err.aread.assert_not_awaited()
-        err.aclose.assert_awaited_once()
+        err.aclose.assert_not_awaited()
 
     @patch("anon_proxy.server.asyncio.sleep", AsyncMock())
     async def test_passthrough_args_to_build_request(self, mock_client):
@@ -360,14 +266,36 @@ class TestUpstreamRequest:
             params={"page": "1"},
         )
 
-    async def test_max_retries_parameter(self, mock_client):
-        """Custom max_retries limits the number of retries."""
-        client, ok = mock_client
-        err = _mock_response(429)
-        client.send.side_effect = [err, err, ok]
 
-        resp = await _upstream_request(
-            client, "POST", "https://example.com/api", max_retries=1
-        )
-        assert resp.status_code == 429  # gave up after 1 retry
-        assert client.send.await_count == 2  # initial + 1 retry
+class TestExtractUsage:
+    def test_anthropic_usage(self):
+        j = {
+            "usage": {
+                "input_tokens": 900,
+                "cache_read_input_tokens": 8000,
+                "cache_creation_input_tokens": 120,
+                "output_tokens": 50,
+            }
+        }
+        assert _extract_usage(j) == {
+            "input": 900,
+            "cache_read": 8000,
+            "cache_creation": 120,
+        }
+
+    def test_openai_usage(self):
+        j = {
+            "usage": {
+                "prompt_tokens": 900,
+                "completion_tokens": 10,
+                "prompt_tokens_details": {"cached_tokens": 700},
+            }
+        }
+        assert _extract_usage(j) == {
+            "input": 900,
+            "cache_read": 700,
+            "cache_creation": 0,
+        }
+
+    def test_no_usage_returns_none(self):
+        assert _extract_usage({}) is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -382,17 +382,15 @@ class TestProxyMaskingConcurrency:
                 transport=transport, base_url="http://testserver"
             ) as client:
                 t0 = time.perf_counter()
-                r1, r2 = await asyncio.gather(
-                    post_messages(client),
-                    post_messages(client),
-                )
+                request_task = asyncio.create_task(post_messages(client))
+                await asyncio.sleep(0.05)
+                loop_delay = time.perf_counter() - t0
+                response = await request_task
                 elapsed = time.perf_counter() - t0
 
-        assert r1.status_code == 200
-        assert r2.status_code == 200
-        assert elapsed < 0.35, (
-            f"requests serialized on the event loop: {elapsed:.2f}s"
-        )
+        assert response.status_code == 200
+        assert loop_delay < 0.15, f"masking blocked the event loop: {loop_delay:.2f}s"
+        assert elapsed >= 0.2
 
 
 class TestCaptureDetectorTelemetry:

--- a/tests/test_store_cli.py
+++ b/tests/test_store_cli.py
@@ -1,0 +1,165 @@
+import json
+
+import pytest
+
+from anon_proxy.store_cli import filter_entries, main, purge_tokens
+
+
+def _store_data():
+    return {
+        "reverse": {
+            "<PERSON_1>": "Alice Smith",
+            "<PERSON_2>": "la",
+            "<EMAIL_1>": "alice@x.com",
+        },
+        "counters": {"PERSON": 2, "EMAIL": 1},
+    }
+
+
+class TestFilterEntries:
+    def test_by_label(self):
+        rows = filter_entries(_store_data(), "PERSON", None, None)
+        assert [r[0] for r in rows] == ["<PERSON_1>", "<PERSON_2>"]
+
+    def test_by_max_len(self):
+        rows = filter_entries(_store_data(), None, None, 3)
+        assert [r[0] for r in rows] == ["<PERSON_2>"]
+
+
+class TestPurge:
+    def test_purge_removes_mapping_keeps_counter(self):
+        data, removed, missing = purge_tokens(_store_data(), ["<PERSON_2>"])
+        assert removed == ["<PERSON_2>"]
+        assert missing == []
+        assert "<PERSON_2>" not in data["reverse"]
+        assert data["counters"]["PERSON"] == 2
+
+    def test_purge_unknown_token_reports_missing(self):
+        data, removed, missing = purge_tokens(_store_data(), ["<PERSON_99>"])
+        assert removed == []
+        assert missing == ["<PERSON_99>"]
+        assert len(data["reverse"]) == 3
+
+
+def _write_store(path):
+    path.write_text(json.dumps(_store_data()))
+
+
+def test_cli_prune_dry_run_changes_nothing(tmp_path, capsys):
+    path = tmp_path / "store.json"
+    _write_store(path)
+
+    rc = main(
+        [
+            "--store",
+            str(path),
+            "prune",
+            "--label",
+            "PERSON",
+            "--max-len",
+            "3",
+            "--dry-run",
+        ]
+    )
+
+    assert rc == 0
+    assert "would remove <PERSON_2>" in capsys.readouterr().out
+    assert json.loads(path.read_text()) == _store_data()
+    assert not (tmp_path / "store.json.bak").exists()
+
+
+def test_cli_prune_requires_filter_or_all(tmp_path, capsys):
+    path = tmp_path / "store.json"
+    _write_store(path)
+
+    with pytest.raises(SystemExit) as exc:
+        main(["--store", str(path), "prune", "--dry-run"])
+
+    assert exc.value.code == 2
+    assert "prune requires at least one filter or --all" in capsys.readouterr().err
+    assert json.loads(path.read_text()) == _store_data()
+
+
+def test_cli_prune_all_requires_explicit_all(tmp_path, capsys):
+    path = tmp_path / "store.json"
+    _write_store(path)
+
+    assert main(["--store", str(path), "prune", "--all", "--dry-run"]) == 0
+
+    out = capsys.readouterr().out
+    assert "would remove <PERSON_1>" in out
+    assert "would remove <PERSON_2>" in out
+    assert "would remove <EMAIL_1>" in out
+
+
+def test_cli_prune_writes_backup_then_modifies(tmp_path):
+    path = tmp_path / "store.json"
+    _write_store(path)
+
+    rc = main(
+        [
+            "--store",
+            str(path),
+            "prune",
+            "--label",
+            "PERSON",
+            "--max-len",
+            "3",
+        ]
+    )
+
+    assert rc == 0
+    assert json.loads((tmp_path / "store.json.bak").read_text()) == _store_data()
+    new = json.loads(path.read_text())
+    assert "<PERSON_2>" not in new["reverse"]
+    assert new["counters"]["PERSON"] == 2
+
+
+def test_cli_purge_writes_backup_then_modifies(tmp_path, capsys):
+    path = tmp_path / "store.json"
+    _write_store(path)
+
+    rc = main(["--store", str(path), "purge", "<EMAIL_1>"])
+
+    assert rc == 0
+    assert "removed <EMAIL_1>" in capsys.readouterr().out
+    assert json.loads((tmp_path / "store.json.bak").read_text()) == _store_data()
+    new = json.loads(path.read_text())
+    assert "<EMAIL_1>" not in new["reverse"]
+    assert new["counters"]["EMAIL"] == 1
+
+
+def test_cli_purge_unknown_token_exits_nonzero(tmp_path, capsys):
+    path = tmp_path / "store.json"
+    _write_store(path)
+
+    assert main(["--store", str(path), "purge", "<PERSON_99>"]) == 1
+
+    captured = capsys.readouterr()
+    assert "not found: <PERSON_99>" in captured.err
+    assert captured.out == ""
+    assert json.loads(path.read_text()) == _store_data()
+    assert not (tmp_path / "store.json.bak").exists()
+
+
+def test_cli_list_and_show(tmp_path, capsys):
+    path = tmp_path / "store.json"
+    _write_store(path)
+
+    assert main(["--store", str(path), "list", "--label", "PERSON"]) == 0
+    list_out = capsys.readouterr().out
+    assert "<PERSON_1>" in list_out
+    assert "Alice Smith" in list_out
+    assert "<EMAIL_1>" not in list_out
+
+    assert main(["--store", str(path), "show", "<EMAIL_1>"]) == 0
+    assert "alice@x.com" in capsys.readouterr().out
+
+
+def test_cli_accepts_store_after_command(tmp_path, capsys):
+    path = tmp_path / "store.json"
+    _write_store(path)
+
+    assert main(["show", "<PERSON_1>", "--store", str(path)]) == 0
+
+    assert "Alice Smith" in capsys.readouterr().out

--- a/uv.lock
+++ b/uv.lock
@@ -31,8 +31,6 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "httpx" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
     { name = "prompt-toolkit" },
     { name = "starlette" },
@@ -57,7 +55,6 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.96.0" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "numpy", specifier = ">=2.2.0" },
     { name = "onnxruntime", marker = "python_full_version >= '3.11' and extra == 'onnx'", specifier = ">=1.20" },
     { name = "onnxruntime", marker = "python_full_version < '3.11' and extra == 'onnx'", specifier = ">=1.20,<1.24" },
     { name = "openai", specifier = ">=2.35.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -31,12 +31,20 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "httpx" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai" },
     { name = "prompt-toolkit" },
     { name = "starlette" },
     { name = "torch" },
     { name = "transformers" },
     { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.optional-dependencies]
+onnx = [
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "onnxruntime", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -49,6 +57,9 @@ dev = [
 requires-dist = [
     { name = "anthropic", specifier = ">=0.96.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "numpy", specifier = ">=2.2.0" },
+    { name = "onnxruntime", marker = "python_full_version >= '3.11' and extra == 'onnx'", specifier = ">=1.20" },
+    { name = "onnxruntime", marker = "python_full_version < '3.11' and extra == 'onnx'", specifier = ">=1.20,<1.24" },
     { name = "openai", specifier = ">=2.35.1" },
     { name = "prompt-toolkit", specifier = ">=3.0.52" },
     { name = "starlette", specifier = ">=1.0.0" },
@@ -56,6 +67,7 @@ requires-dist = [
     { name = "transformers", specifier = ">=5.6.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.45.0" },
 ]
+provides-extras = ["onnx"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -133,6 +145,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coloredlogs"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanfriendly", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
 ]
 
 [[package]]
@@ -245,6 +269,14 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -386,6 +418,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dc/89/e7aa12d8a6b9259bed10671abb25ae6fa437c0f88a86ecbf59617bae7759/huggingface_hub-1.11.0.tar.gz", hash = "sha256:15fb3713c7f9cdff7b808a94fd91664f661ab142796bb48c9cd9493e8d166278", size = 761749, upload-time = "2026-04-16T13:07:39.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/02/4f3f8997d1ea7fe0146b343e5e14bd065fa87af790d07e5576d31b31cc18/huggingface_hub-1.11.0-py3-none-any.whl", hash = "sha256:42a6de0afbfeb5e022222d36398f029679db4eb4778801aafda32257ae9131ab", size = 645499, upload-time = "2026-04-16T13:07:37.716Z" },
+]
+
+[[package]]
+name = "humanfriendly"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyreadline3", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
 ]
 
 [[package]]
@@ -957,6 +1001,86 @@ wheels = [
 ]
 
 [[package]]
+name = "onnxruntime"
+version = "1.23.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "coloredlogs", marker = "python_full_version < '3.11'" },
+    { name = "flatbuffers", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "protobuf", marker = "python_full_version < '3.11'" },
+    { name = "sympy", marker = "python_full_version < '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/d6/311b1afea060015b56c742f3531168c1644650767f27ef40062569960587/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3", size = 17195934, upload-time = "2025-10-27T23:06:14.143Z" },
+    { url = "https://files.pythonhosted.org/packages/db/db/81bf3d7cecfbfed9092b6b4052e857a769d62ed90561b410014e0aae18db/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:b28740f4ecef1738ea8f807461dd541b8287d5650b5be33bca7b474e3cbd1f36", size = 19153079, upload-time = "2025-10-27T23:05:57.686Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4d/a382452b17cf70a2313153c520ea4c96ab670c996cb3a95cc5d5ac7bfdac/onnxruntime-1.23.2-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f7d1fe034090a1e371b7f3ca9d3ccae2fabae8c1d8844fb7371d1ea38e8e8d2", size = 15219883, upload-time = "2025-10-22T03:46:21.66Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/56/179bf90679984c85b417664c26aae4f427cba7514bd2d65c43b181b7b08b/onnxruntime-1.23.2-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4ca88747e708e5c67337b0f65eed4b7d0dd70d22ac332038c9fc4635760018f7", size = 17370357, upload-time = "2025-10-22T03:46:57.968Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6d/738e50c47c2fd285b1e6c8083f15dac1a5f6199213378a5f14092497296d/onnxruntime-1.23.2-cp310-cp310-win_amd64.whl", hash = "sha256:0be6a37a45e6719db5120e9986fcd30ea205ac8103fd1fb74b6c33348327a0cc", size = 13467651, upload-time = "2025-10-27T23:06:11.904Z" },
+    { url = "https://files.pythonhosted.org/packages/44/be/467b00f09061572f022ffd17e49e49e5a7a789056bad95b54dfd3bee73ff/onnxruntime-1.23.2-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:6f91d2c9b0965e86827a5ba01531d5b669770b01775b23199565d6c1f136616c", size = 17196113, upload-time = "2025-10-22T03:47:33.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a8/3c23a8f75f93122d2b3410bfb74d06d0f8da4ac663185f91866b03f7da1b/onnxruntime-1.23.2-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:87d8b6eaf0fbeb6835a60a4265fde7a3b60157cf1b2764773ac47237b4d48612", size = 19153857, upload-time = "2025-10-22T03:46:37.578Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d8/506eed9af03d86f8db4880a4c47cd0dffee973ef7e4f4cff9f1d4bcf7d22/onnxruntime-1.23.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbfd2fca76c855317568c1b36a885ddea2272c13cb0e395002c402f2360429a6", size = 15220095, upload-time = "2025-10-22T03:46:24.769Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/80/113381ba832d5e777accedc6cb41d10f9eca82321ae31ebb6bcede530cea/onnxruntime-1.23.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da44b99206e77734c5819aa2142c69e64f3b46edc3bd314f6a45a932defc0b3e", size = 17372080, upload-time = "2025-10-22T03:47:00.265Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/db/1b4a62e23183a0c3fe441782462c0ede9a2a65c6bbffb9582fab7c7a0d38/onnxruntime-1.23.2-cp311-cp311-win_amd64.whl", hash = "sha256:902c756d8b633ce0dedd889b7c08459433fbcf35e9c38d1c03ddc020f0648c6e", size = 13468349, upload-time = "2025-10-22T03:47:25.783Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9e/f748cd64161213adeef83d0cb16cb8ace1e62fa501033acdd9f9341fff57/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:b8f029a6b98d3cf5be564d52802bb50a8489ab73409fa9db0bf583eabb7c2321", size = 17195929, upload-time = "2025-10-22T03:47:36.24Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9d/a81aafd899b900101988ead7fb14974c8a58695338ab6a0f3d6b0100f30b/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:218295a8acae83905f6f1aed8cacb8e3eb3bd7513a13fe4ba3b2664a19fc4a6b", size = 19157705, upload-time = "2025-10-22T03:46:40.415Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/4e40f2fba272a6698d62be2cd21ddc3675edfc1a4b9ddefcc4648f115315/onnxruntime-1.23.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76ff670550dc23e58ea9bc53b5149b99a44e63b34b524f7b8547469aaa0dcb8c", size = 15226915, upload-time = "2025-10-22T03:46:27.773Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/88/9cc25d2bafe6bc0d4d3c1db3ade98196d5b355c0b273e6a5dc09c5d5d0d5/onnxruntime-1.23.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f9b4ae77f8e3c9bee50c27bc1beede83f786fe1d52e99ac85aa8d65a01e9b77", size = 17382649, upload-time = "2025-10-22T03:47:02.782Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b4/569d298f9fc4d286c11c45e85d9ffa9e877af12ace98af8cab52396e8f46/onnxruntime-1.23.2-cp312-cp312-win_amd64.whl", hash = "sha256:25de5214923ce941a3523739d34a520aac30f21e631de53bba9174dc9c004435", size = 13470528, upload-time = "2025-10-22T03:47:28.106Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/41/fba0cabccecefe4a1b5fc8020c44febb334637f133acefc7ec492029dd2c/onnxruntime-1.23.2-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:2ff531ad8496281b4297f32b83b01cdd719617e2351ffe0dba5684fb283afa1f", size = 17196337, upload-time = "2025-10-22T03:46:35.168Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f9/2d49ca491c6a986acce9f1d1d5fc2099108958cc1710c28e89a032c9cfe9/onnxruntime-1.23.2-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:162f4ca894ec3de1a6fd53589e511e06ecdc3ff646849b62a9da7489dee9ce95", size = 19157691, upload-time = "2025-10-22T03:46:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a1/428ee29c6eaf09a6f6be56f836213f104618fb35ac6cc586ff0f477263eb/onnxruntime-1.23.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45d127d6e1e9b99d1ebeae9bcd8f98617a812f53f46699eafeb976275744826b", size = 15226898, upload-time = "2025-10-22T03:46:30.039Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/2b/b57c8a2466a3126dbe0a792f56ad7290949b02f47b86216cd47d857e4b77/onnxruntime-1.23.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8bace4e0d46480fbeeb7bbe1ffe1f080e6663a42d1086ff95c1551f2d39e7872", size = 17382518, upload-time = "2025-10-22T03:47:05.407Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/93/aba75358133b3a941d736816dd392f687e7eab77215a6e429879080b76b6/onnxruntime-1.23.2-cp313-cp313-win_amd64.whl", hash = "sha256:1f9cc0a55349c584f083c1c076e611a7c35d5b867d5d6e6d6c823bf821978088", size = 13470276, upload-time = "2025-10-22T03:47:31.193Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3d/6830fa61c69ca8e905f237001dbfc01689a4e4ab06147020a4518318881f/onnxruntime-1.23.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9d2385e774f46ac38f02b3a91a91e30263d41b2f1f4f26ae34805b2a9ddef466", size = 15229610, upload-time = "2025-10-22T03:46:32.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ca/862b1e7a639460f0ca25fd5b6135fb42cf9deea86d398a92e44dfda2279d/onnxruntime-1.23.2-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2b9233c4947907fd1818d0e581c049c41ccc39b2856cc942ff6d26317cee145", size = 17394184, upload-time = "2025-10-22T03:47:08.127Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+]
+dependencies = [
+    { name = "flatbuffers", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/e4/5353d7e09ced4a8f473f843223fc75d726b2b5519dcefc12f22a6c92852d/onnxruntime-1.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:8ba14a38c570087f3cdb8cfba33f7a38a1e826c1e5b29e17c28ceda0cc910016", size = 18416484, upload-time = "2026-06-15T22:43:43.894Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1f/a2117aa3f144fce88774efa37440d0ca72d0c9144854dfc0961f2b04c6fc/onnxruntime-1.27.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2eb083321af8a236a84c7c140a7f4cecbfa2a987a18c07c78db471c20cd390ef", size = 16419330, upload-time = "2026-06-15T22:42:37.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/cd/74bb804170ceb622fda9111df31a07b3024f7491472256d3a90b5391a4d2/onnxruntime-1.27.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e4f7b0e90d2d212e2c2deaa6c8291616183ab815d3ec558ea12d3ac8b26d36f4", size = 18636930, upload-time = "2026-06-15T22:43:01.584Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8f/5b8e2b85e81735696887175dbaf6409f215683f5ca9d4928fbb038211d32/onnxruntime-1.27.0-cp311-cp311-win_amd64.whl", hash = "sha256:ff050e4f6bf7f12918fa14dcb047c0b02e295f35e86d42532552be4b3d54e977", size = 13356110, upload-time = "2026-06-15T22:43:32.172Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3a/4f568de678126b6a371a93862f015a82138359decd97fcac61fc84b5b774/onnxruntime-1.27.0-cp311-cp311-win_arm64.whl", hash = "sha256:75fbc1e1fb43a39a856c8209c544cca7817b5de7ac16b15b1bdf55d1cc67b9df", size = 13098635, upload-time = "2026-06-15T22:43:19.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/dd3a524ed93a820dff1af902d0412957ab12499953333e9daa01af5bc480/onnxruntime-1.27.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:a14c2ce45312def86b77aea651f46565e45960cf5f0721bfdff449165086ab76", size = 18433506, upload-time = "2026-06-15T22:43:47.026Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/c3b6b17745a1997d784dadc9bd88d713d2e6721139a5a0e885b28cfb79b1/onnxruntime-1.27.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6fddce0539a4898c7bef35b052ffd37935b2190e35488eab99ce91887743ea1", size = 16438140, upload-time = "2026-06-15T22:42:40.666Z" },
+    { url = "https://files.pythonhosted.org/packages/26/81/24dd9b31b0fb912ee19ca53ac1c9764bfd79d58a2ccef564eb693be831a5/onnxruntime-1.27.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c65a7438632d55dfbc8a02ee60bd6cf7dd9d1ba05a43d4b851452f32338e194", size = 18658316, upload-time = "2026-06-15T22:43:04.012Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/88/8ec9db1a4d126bb8b758992beb40d1249df171917d75f44a327eb5f20dda/onnxruntime-1.27.0-cp312-cp312-win_amd64.whl", hash = "sha256:20c321cf187ba496e648acf6b4cf90b4d398b0d17c2a77fdaeba365b908cc1c1", size = 13358769, upload-time = "2026-06-15T22:43:34.581Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/9f/fdad359dfcba7e7cd8815569b304a596531d4efa77a75d77f8b4981891a2/onnxruntime-1.27.0-cp312-cp312-win_arm64.whl", hash = "sha256:d0d1f68868e2ef30ef70998ba9bbbc5c305e9b17041e3936751c1b8aa6aade06", size = 13104440, upload-time = "2026-06-15T22:43:22.893Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/2b/54208fd03ad410480bc17edf4869376362da8bbf46fe186ddf4cb5cc20fe/onnxruntime-1.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:b3e5b58b8c89c2b20e086e890aa9527377e5c240dc3ecc1640d18e07705eeb1c", size = 18432958, upload-time = "2026-06-15T22:42:53.105Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/24fc51fcbb126da6d032372314e47b55c3faad58f2aa78c0e199ccd20b9c/onnxruntime-1.27.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48b3d87eb560ff6a772240506f3c78d6d27c63cafedd5c775672e1194f968cfd", size = 16438180, upload-time = "2026-06-15T22:42:43.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/19/14929c3c2fe0b79b41cce24463062bf3afa4cdd3c19dccf00319caa92bff/onnxruntime-1.27.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6872443f236a554921cda6f318c900e2d0c226792cf3534d00e5057c6926e5d2", size = 18658445, upload-time = "2026-06-15T22:43:08.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/76/59ed932b0244acd7bbbd6449480053a6d958ea66357f022f932872e19287/onnxruntime-1.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:760021bca514d64a811837820d351a08a41741f16f8b4c26450da708fecf14e6", size = 13357856, upload-time = "2026-06-15T22:43:37.315Z" },
+    { url = "https://files.pythonhosted.org/packages/79/51/d1ec60ec7b1e2ae2d7340ba52b8a13529140039cd4407ba8dddbbc046582/onnxruntime-1.27.0-cp313-cp313-win_arm64.whl", hash = "sha256:2fdfa9df40a0ded0028ce6f9cd863264237f3970559dea2b81456e9ac4622b94", size = 13104412, upload-time = "2026-06-15T22:43:27.457Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7d/e6bb1c6445c94f708c38cd8fbb7bf0264108c33498b9445c93e60fe6d329/onnxruntime-1.27.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54c0c4e9202c36c4ecdb1f3443f5dfbfd5ee3b54d1362c4b4c6134110e74fb32", size = 16443331, upload-time = "2026-06-15T22:42:45.649Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/b18b31e806eabc41077810199fbbb36fbc2d5f19912416e5ccfbf73053d1/onnxruntime-1.27.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1b215aa662c8f983f7d6dedafe65a9be72c26e5338e0fe98b3e0422c32c85428", size = 18670967, upload-time = "2026-06-15T22:43:10.621Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/37/48ab79c39b58a7c9f6f5aac1fa0ff2b993eb2643393d6ed9e839ddb6f347/onnxruntime-1.27.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:0874edc171f470fc4dd2bbb60bc0989612ed1a8b89b365cda016630a93227f13", size = 18433941, upload-time = "2026-06-15T22:42:58.867Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/24/d535ca8a09dbf697f853377c8dc0820dbcaae5f334316b400b953afbcba8/onnxruntime-1.27.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5b51c014cf1a4fcd93c29a97eac8071fa27710dae05a4d0380bb60a66d60a62c", size = 16439970, upload-time = "2026-06-15T22:42:48.023Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b1/ea9ee80c0bdaa4efb13f29f8c236f3740f6655e8c092a2d119515a5a652c/onnxruntime-1.27.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:445fb702ea5241ba813a3ce2febe2e9408a64f6ad2eb610924322c536165f7cd", size = 18659240, upload-time = "2026-06-15T22:43:13.165Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f2/1404507d76a21940e8bf46f414e3d1abd94dc888cb89a30f4a540275846f/onnxruntime-1.27.0-cp314-cp314-win_amd64.whl", hash = "sha256:49e416be0d717338b6d041b99911b716d70c397d277056450724f93bdded3fc2", size = 13685306, upload-time = "2026-06-15T22:43:40.416Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e5/ca5cf012ccccb806c70e94aadfebca5606acc62b33eb88cec13352d0778f/onnxruntime-1.27.0-cp314-cp314-win_arm64.whl", hash = "sha256:856032937dd3bc7a7c141909c8d7ae4fde3e3f59bddf061ae627b9a051bda95c", size = 13456280, upload-time = "2026-06-15T22:43:29.693Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7b/dca330a8397e9d816c976d7aed4e24a4a2d279bb1e551e3d0221d1389b1d/onnxruntime-1.27.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c6197a02e3f620c4dc13cff51b80672409fc1ffab3aa2593911b19fd322ff48b", size = 16443274, upload-time = "2026-06-15T22:42:50.467Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f6/2bac21f722aa45d876d4a51f26bd0ef30e704068a3cd5021a5a7cd784271/onnxruntime-1.27.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:370d211e1ceeac4cd5f45301655463ac59e27cdc74d9f7aeb2d19ff4b7a76715", size = 18670781, upload-time = "2026-06-15T22:43:17.151Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.35.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1003,6 +1127,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]
@@ -1143,6 +1282,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyreadline3"
+version = "3.5.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/6d/f94028646d7bbe6d9d873c47ee7c246f2d29129d253f0d96cb6fcab70733/pyreadline3-3.5.6.tar.gz", hash = "sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf", size = 100368, upload-time = "2026-05-14T17:55:04.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/5e/35c856e186b74678c24927847ad9895a51f1bc02a0c6126477a6c6040064/pyreadline3-3.5.6-py3-none-any.whl", hash = "sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d", size = 85243, upload-time = "2026-05-14T17:55:03.262Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Summary:\n- Remove the advertised MLX backend/cache flags that crash at startup; public crash issue: #15.\n- Add an optional ONNX Runtime privacy-filter backend using the upstream openai/privacy-filter ONNX export, with an Optimum-first loader and raw onnxruntime fallback when Optimum is unavailable or incompatible.\n- Keep chunking, batching, masking, merge behavior, and server flag wiring on the existing PrivacyFilter surface.\n- Add safe detector telemetry reporting, persistent store cleanup CLI, and backend parity/benchmark gates.\n\nBase: main. This is a main-based PR; origin/main was fetched and verified as an ancestor before commit.\n\nTest plan:\n- uv run pytest tests/ --collect-only -q\n- uv run pytest -q\n- uv run --with ruff ruff check\n- uv run --with ruff ruff format --check\n- uv run --extra onnx python -c "from anon_proxy.privacy_filter import PrivacyFilter; text='Alice Smith called from 555-867-5309 about bob@example.com.'; pf=PrivacyFilter(backend='onnx'); print([(e.label, e.text, e.start, e.end, round(e.score, 4)) for e in pf.detect(text)])"\n- uv run --extra onnx anon-proxy-backend-eval --iterations 3 --warmups 1 --json\n- uv run python -m anon_proxy.server --help\n- git diff --check\n\nBackend gate result:\n- Parity passed: ONNX missed no torch-detected entity on the built-in samples.\n- Benchmark passed: ONNX warm median 0.200s vs torch 0.323s, 38.0% faster, above the 30% gate.\n